### PR TITLE
Dynamically building a sln file

### DIFF
--- a/TaskManager/run.cmd
+++ b/TaskManager/run.cmd
@@ -1,1 +1,0 @@
-dotnet workflowcoordinator.dll

--- a/TaskManager/run.cmd
+++ b/TaskManager/run.cmd
@@ -1,0 +1,1 @@
+dotnet workflowcoordinator.dll

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -36,9 +36,19 @@ steps:
 - powershell: dotnet publish $(workflowCoordinator) --no-build --output $(Build.ArtifactStagingDirectory)\workflowCoordinator
   displayName: Publish Workflow Coordinator
 
+- task: DownloadSecureFile@1
+  inputs:
+    secureFile: 'License.xml'
+  name: 'nsblicense'
+  displayName: 'Download NSB License from Secure Files'
+
+- powershell: copy-item $(nsblicense.secureFilePath) .\
+  workingDirectory: $(Build.ArtifactStagingDirectory)\workflowCoordinator 
+  displayName: Copy NSB License into the artifact 
+
 - powershell: '"dotnet workflowcoordinator.dll" | Out-File run.cmd -Encoding ASCII; $LASTEXITCODE'
   workingDirectory: $(Build.ArtifactStagingDirectory)\workflowCoordinator  
-  displayName: Generate run.cmd
+  displayName: Generate run.cmd and add to the artiface 
 
 # - task: PublishBuildArtifacts@1
 #   inputs:

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -50,9 +50,9 @@ steps:
   workingDirectory: $(Build.ArtifactStagingDirectory)\workflowCoordinator  
   displayName: Generate run.cmd and add to the artifact
 
-# - task: PublishBuildArtifacts@1
-#   inputs:
-#     PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-#     ArtifactName: 'workflowcoordinator'
-#   displayName: 'Publish workflowcoordinator Artifact'
+- task: PublishBuildArtifacts@1
+  inputs:
+    PathtoPublish: $(Build.ArtifactStagingDirectory)
+    ArtifactName: workflowcoordinator
+  displayName: Publish workflowcoordinator Artifact
 

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -33,7 +33,7 @@ steps:
   displayName: Publish Workflow Coordinator
 
 - powershell: '"dotnet workflowcoordinator.dll" | Out-File run.cmd -Encoding ASCII; $LASTEXITCODE'
-  workingDirectory: $(Build.ArtifactStagingDirectory)\workflowCoordinator'  
+  workingDirectory: $(Build.ArtifactStagingDirectory)\workflowCoordinator  
   displayName: Generate run.cmd
 
 # - task: PublishBuildArtifacts@1

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -2,7 +2,7 @@ trigger:
 - master
 
 pool:
-  vmImage: 'UKHO Windows 2019'
+  name: 'UKHO Windows 2019'
 
 steps:
 

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -1,8 +1,3 @@
-# Starter pipeline
-# Start with a minimal pipeline that you can customize to build and deploy your code.
-# Add steps that build, run tests, deploy, and more:
-# https://aka.ms/yaml
-
 trigger:
 - master
 
@@ -11,58 +6,40 @@ pool:
 
 steps:
 
-- task: DotNetCoreCLI@2
-  inputs:
-    command: 'restore'
-    projects: '$(Build.SourcesDirectory)\\taskmanager\\workflowcoordinator\\workflowcoordinator.csproj'
-    feedsToUse: 'select'
-  displayName: 'dotnet restore workflowcoordinator'
+- powershell: dotnet restore $(Build.SourcesDirectory)\taskmanager\workflowcoordinator\workflowcoordinator.csproj
+  displayName: Restore Workflow Coordinator packages
 
-- task: DotNetCoreCLI@2
-  inputs:
-    command: 'build'
-    projects: '$(Build.SourcesDirectory)\\taskmanager\\workflowcoordinator\\workflowcoordinator.csproj'
-  displayName: 'dotnet build workflowcoordinator'
+- powershell: dotnet restore $(Build.SourcesDirectory)\taskmanager\workflowcoordinatortests\workflowcoordinatortests.csproj
+  displayName: Restore Workflow Coordinator test packages
 
-- task: DotNetCoreCLI@2
-  inputs:
-    command: 'restore'
-    projects: '$(Build.SourcesDirectory)\\taskmanager\\workflowcoordinatortests\\workflowcoordinatortests.csproj'
-    feedsToUse: 'select'
-  displayName: 'dotnet restore workflowcoordinatortests'
+- powershell: dotnet build $(Build.SourcesDirectory)\taskmanager\workflowcoordinator\workflowcoordinator.csproj --no-restore
+  displayName: Build Workflow Coordinator
 
-- task: DotNetCoreCLI@2
-  inputs:
-    command: 'build'
-    projects: '$(Build.SourcesDirectory)\\taskmanager\\workflowcoordinatortests\\workflowcoordinatortests.csproj'
-  displayName: 'dotnet build workflowcoordinatortests'
+- powershell: dotnet build $(Build.SourcesDirectory)\taskmanager\workflowcoordinatortests\workflowcoordinatortests.csproj --no-restore
+  displayName: Build Workflow Coordinator Tests
 
-- task: DotNetCoreCLI@2
-  inputs:
-    command: 'test'
-    projects: '$(Build.SourcesDirectory)\\taskmanager\\workflowcoordinatortests\\workflowcoordinatortests.csproj'
-  displayName: 'dotnet test workflowcoordinatortests'
+- powershell: dotnet test $(Build.SourcesDirectory)\taskmanager\workflowcoordinatortests\workflowcoordinatortests.csproj --no-build --logger:trx -r $(Agent.BuildDirectory)/TestResults 
+  displayName: Test Workflow Coordinator
 
-- task: DotNetCoreCLI@2
+- task: PublishTestResults@2
+  displayName: Publish Test Results
   inputs:
-    command: 'publish'
-    publishWebProjects: false
-    projects: '$(Build.SourcesDirectory)\\taskmanager\\workflowcoordinator\\workflowcoordinator.csproj'
-    zipAfterPublish: false
-    arguments: '--output $(Build.ArtifactStagingDirectory)\\WebJob\\App_Data\\jobs\\continuous'
-  displayName: 'Publish Solution'
+    testRunner: VSTest
+    testResultsFiles: '$(Agent.BuildDirectory)/TestResults/*.trx'
+    failTaskOnFailedTests: true
+    mergeTestResults: true
 
-- task: PowerShell@2
-  inputs:
-    targetType: 'inline'
-    script: '"dotnet workflowcoordinator.dll" | Out-File run.cmd -Encoding ASCII; $LASTEXITCODE'
-    workingDirectory: '$(Build.ArtifactStagingDirectory)\\WebJob\\App_Data\\jobs\\continuous\\workflowcoordinator'
-  displayName: 'Generate run.cmd'
+- powershell: dotnet publish $(Build.SourcesDirectory)\taskmanager\workflowcoordinator\workflowcoordinator.csproj --no-build --output $(Build.ArtifactStagingDirectory)\workflowCoordinator
+  displayName: Publish Workflow Coordinator
 
-- task: PublishBuildArtifacts@1
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-    ArtifactName: 'workflowcoordinator'
-    publishLocation: 'Container'
-  displayName: 'Publish workflowcoordinator Artifact'
+- powershell: '"dotnet workflowcoordinator.dll" | Out-File run.cmd -Encoding ASCII; $LASTEXITCODE'
+  workingDirectory: $(Build.ArtifactStagingDirectory)\workflowCoordinator\workflowcoordinator'  
+  displayName: Generate run.cmd
+
+# - task: PublishBuildArtifacts@1
+#   inputs:
+#     PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+#     ArtifactName: 'workflowcoordinator'
+#     publishLocation: 'Container'
+#   displayName: 'Publish workflowcoordinator Artifact'
 

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -48,7 +48,7 @@ steps:
 
 - powershell: '"dotnet workflowcoordinator.dll" | Out-File run.cmd -Encoding ASCII; $LASTEXITCODE'
   workingDirectory: $(Build.ArtifactStagingDirectory)\workflowCoordinator  
-  displayName: Generate run.cmd and add to the artiface 
+  displayName: Generate run.cmd and add to the artifact
 
 # - task: PublishBuildArtifacts@1
 #   inputs:

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -1,6 +1,7 @@
 variables:
   workflowCoordinator: $(Build.SourcesDirectory)\taskmanager\workflowcoordinator\workflowcoordinator.csproj
   workflowCoordinatorTests: $(Build.SourcesDirectory)\taskmanager\workflowcoordinatortests\workflowcoordinatortests.csproj
+  taskmanagerDir: $(Build.SourcesDirectory)\TaskManager
 
 trigger:
 - master
@@ -10,6 +11,13 @@ pool:
 
 steps:
 
+- powershell: |
+    dotnet sln remove (dir **/*.csproj)
+    dotnet sln add $(workflowCoordinator) $(workflowCoordinatorTests)
+    dotnet sln list
+  workingDirectory: $(taskmanagerDir)
+  displayName: Remove all .csprojs and add relevent projects
+  
 - powershell: dotnet restore $(workflowCoordinator)
   displayName: Restore Workflow Coordinator packages
 

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -2,7 +2,7 @@ trigger:
 - master
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'UKHO Windows 2019'
 
 steps:
 
@@ -33,7 +33,7 @@ steps:
   displayName: Publish Workflow Coordinator
 
 - powershell: '"dotnet workflowcoordinator.dll" | Out-File run.cmd -Encoding ASCII; $LASTEXITCODE'
-  workingDirectory: $(Build.ArtifactStagingDirectory)\workflowCoordinator\workflowcoordinator'  
+  workingDirectory: $(Build.ArtifactStagingDirectory)\workflowCoordinator\'  
   displayName: Generate run.cmd
 
 # - task: PublishBuildArtifacts@1

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -2,6 +2,8 @@ variables:
   workflowCoordinator: $(Build.SourcesDirectory)\taskmanager\workflowcoordinator\workflowcoordinator.csproj
   workflowCoordinatorTests: $(Build.SourcesDirectory)\taskmanager\workflowcoordinatortests\workflowcoordinatortests.csproj
   taskmanagerDir: $(Build.SourcesDirectory)\TaskManager
+  taskmanagerSln: $(taskmanagerDir)\TaskManager.sln
+  configuration: Release
 
 trigger:
 - master
@@ -14,23 +16,16 @@ steps:
 - powershell: |
     dotnet sln remove (dir **/*.csproj)
     dotnet sln add $(workflowCoordinator) $(workflowCoordinatorTests)
-    dotnet sln list
   workingDirectory: $(taskmanagerDir)
   displayName: Remove all .csprojs and add relevent projects
   
-- powershell: dotnet restore $(workflowCoordinator)
-  displayName: Restore Workflow Coordinator packages
+- powershell: dotnet restore $(taskmanagerSln)
+  displayName: Restore packages
 
-- powershell: dotnet restore $(workflowCoordinatorTests)
-  displayName: Restore Workflow Coordinator test packages
-
-- powershell: dotnet build $(workflowCoordinator) --no-restore
-  displayName: Build Workflow Coordinator
-
-- powershell: dotnet build $(workflowCoordinatorTests) --no-restore
+- powershell: dotnet build $(taskmanagerSln) --no-restore -c $(configuration)
   displayName: Build Workflow Coordinator Tests
 
-- powershell: dotnet test $(workflowCoordinatorTests) --no-build --logger:trx -r $(Agent.BuildDirectory)/TestResults 
+- powershell: dotnet test $(taskmanagerSln) --no-build -c $(configuration) --logger:trx -r $(Agent.BuildDirectory)/TestResults 
   displayName: Test Workflow Coordinator
 
 - task: PublishTestResults@2

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -33,7 +33,7 @@ steps:
   displayName: Publish Workflow Coordinator
 
 - powershell: '"dotnet workflowcoordinator.dll" | Out-File run.cmd -Encoding ASCII; $LASTEXITCODE'
-  workingDirectory: $(Build.ArtifactStagingDirectory)\workflowCoordinator\'  
+  workingDirectory: $(Build.ArtifactStagingDirectory)\workflowCoordinator'  
   displayName: Generate run.cmd
 
 # - task: PublishBuildArtifacts@1

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -1,3 +1,7 @@
+variables:
+  workflowCoordinator: $(Build.SourcesDirectory)\taskmanager\workflowcoordinator\workflowcoordinator.csproj
+  workflowCoordinatorTests: $(Build.SourcesDirectory)\taskmanager\workflowcoordinatortests\workflowcoordinatortests.csproj
+
 trigger:
 - master
 
@@ -6,19 +10,19 @@ pool:
 
 steps:
 
-- powershell: dotnet restore $(Build.SourcesDirectory)\taskmanager\workflowcoordinator\workflowcoordinator.csproj
+- powershell: dotnet restore $(workflowCoordinator)
   displayName: Restore Workflow Coordinator packages
 
-- powershell: dotnet restore $(Build.SourcesDirectory)\taskmanager\workflowcoordinatortests\workflowcoordinatortests.csproj
+- powershell: dotnet restore $(workflowCoordinatorTests)
   displayName: Restore Workflow Coordinator test packages
 
-- powershell: dotnet build $(Build.SourcesDirectory)\taskmanager\workflowcoordinator\workflowcoordinator.csproj --no-restore
+- powershell: dotnet build $(workflowCoordinator) --no-restore
   displayName: Build Workflow Coordinator
 
-- powershell: dotnet build $(Build.SourcesDirectory)\taskmanager\workflowcoordinatortests\workflowcoordinatortests.csproj --no-restore
+- powershell: dotnet build $(workflowCoordinatorTests) --no-restore
   displayName: Build Workflow Coordinator Tests
 
-- powershell: dotnet test $(Build.SourcesDirectory)\taskmanager\workflowcoordinatortests\workflowcoordinatortests.csproj --no-build --logger:trx -r $(Agent.BuildDirectory)/TestResults 
+- powershell: dotnet test $(workflowCoordinatorTests) --no-build --logger:trx -r $(Agent.BuildDirectory)/TestResults 
   displayName: Test Workflow Coordinator
 
 - task: PublishTestResults@2
@@ -29,7 +33,7 @@ steps:
     failTaskOnFailedTests: true
     mergeTestResults: true
 
-- powershell: dotnet publish $(Build.SourcesDirectory)\taskmanager\workflowcoordinator\workflowcoordinator.csproj --no-build --output $(Build.ArtifactStagingDirectory)\workflowCoordinator
+- powershell: dotnet publish $(workflowCoordinator) --no-build --output $(Build.ArtifactStagingDirectory)\workflowCoordinator
   displayName: Publish Workflow Coordinator
 
 - powershell: '"dotnet workflowcoordinator.dll" | Out-File run.cmd -Encoding ASCII; $LASTEXITCODE'
@@ -40,6 +44,5 @@ steps:
 #   inputs:
 #     PathtoPublish: '$(Build.ArtifactStagingDirectory)'
 #     ArtifactName: 'workflowcoordinator'
-#     publishLocation: 'Container'
 #   displayName: 'Publish workflowcoordinator Artifact'
 


### PR DESCRIPTION
> NB - This could be solving a non existent problem. Depending on how you structure your builds and projects you might not never feel the possible pain. 

PR created to show a possibility. Not intended for merging.

You might run into the problem where you have lots of repetitive restore and build steps in your pipeline as you can't point at a single .sln to build, this you means you need to build relevant .csprojs individually.

This PR uses the build to modify the single existing `taskmanager.sln`, it removes all the .csprojs from the sln and then add backs in the projects you want to build by using the `dotnet sln` command. You can then pass the modified sln to restore, build and test and it will only do the work for the projects re-added to the sln. 

This could be easier to read, understand and debug than repeated steps.

But, instead of this approach, you could also in theory just always build the unit test project which will build all the class libraries needed automatically and again only have a single restore, build and test. That approach might struggle with projects where you have separate unit tests and integration tests though.