### PR TITLE
Features/fix nightly pipeline triggers

### DIFF
--- a/portal-nightly-azure-pipelines.yml
+++ b/portal-nightly-azure-pipelines.yml
@@ -3,6 +3,8 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
+trigger: none
+
 pr: none
 
 schedules:


### PR DESCRIPTION
For the nightly Portal pipeline:
- Do not run CI builds
- Do not run PR builds