### PR TITLE
Features/start db assessment saga tests

### DIFF
--- a/src/Common.Helpers/OptionsSnapshotWrapper.cs
+++ b/src/Common.Helpers/OptionsSnapshotWrapper.cs
@@ -1,0 +1,20 @@
+using System;
+using Microsoft.Extensions.Options;
+
+namespace Common.Helpers
+{
+    public class OptionsSnapshotWrapper<TOptions> : IOptionsSnapshot<TOptions> where TOptions : class, new()
+    {
+        public TOptions Value { get; }
+
+        public OptionsSnapshotWrapper(TOptions options)
+        {
+            Value = options;
+        }
+
+        public TOptions Get(string name)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/DataServices/DataServices/Properties/launchSettings.json
+++ b/src/DataServices/DataServices/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:27720/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "DataServices": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:27720/"
+    }
+  }
+}

--- a/src/TaskManager.sln
+++ b/src/TaskManager.sln
@@ -53,7 +53,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common.Messages", "Common\C
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common.Helpers", "Common.Helpers\Common.Helpers.csproj", "{C7BC619D-7B09-417F-BC2A-43B79FF28541}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataServices.Models", "DataServices\DataServices.Models\DataServices.Models.csproj", "{6B6269AD-C400-4A5E-B6F8-19E5036BF127}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataServices.Models", "DataServices\DataServices.Models\DataServices.Models.csproj", "{6B6269AD-C400-4A5E-B6F8-19E5036BF127}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WorkflowCoordinator.IntegrationTests", "WorkflowCoordinator.IntegrationTests\WorkflowCoordinator.IntegrationTests.csproj", "{2C01990D-AE78-4265-BA7E-4C72CA01AC25}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -139,6 +141,10 @@ Global
 		{6B6269AD-C400-4A5E-B6F8-19E5036BF127}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6B6269AD-C400-4A5E-B6F8-19E5036BF127}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6B6269AD-C400-4A5E-B6F8-19E5036BF127}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C01990D-AE78-4265-BA7E-4C72CA01AC25}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C01990D-AE78-4265-BA7E-4C72CA01AC25}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C01990D-AE78-4265-BA7E-4C72CA01AC25}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C01990D-AE78-4265-BA7E-4C72CA01AC25}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -163,6 +169,7 @@ Global
 		{2F6F8E7E-CB8F-4E3A-AE1B-6FA25BF99BC8} = {DB5D8B0D-04B0-4929-A5B8-BE892037D846}
 		{C7BC619D-7B09-417F-BC2A-43B79FF28541} = {DB5D8B0D-04B0-4929-A5B8-BE892037D846}
 		{6B6269AD-C400-4A5E-B6F8-19E5036BF127} = {9C5DE816-B215-42DD-8ED2-A00895B4CDF6}
+		{2C01990D-AE78-4265-BA7E-4C72CA01AC25} = {AC6D37BD-D8E4-418F-B062-4B7CC6A8FD1A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {77269532-E17B-46D3-943A-11A10CA36E74}

--- a/src/WorkflowCoordinator.IntegrationTests/StartDbAssessmentSagaTests.cs
+++ b/src/WorkflowCoordinator.IntegrationTests/StartDbAssessmentSagaTests.cs
@@ -69,7 +69,7 @@ namespace WorkflowCoordinator.IntegrationTests
         public async Task Test_StartDbAssessmentCommand_Saves_Saga_Data()
         {
             // Given
-            _sdocId = RandomiseSdcoId();
+            _sdocId = 1111; // RandomiseSdcoId();
             var correlationId = Guid.NewGuid();
             var startDbAssessmentCommand = new StartDbAssessmentCommand
             {
@@ -86,6 +86,13 @@ namespace WorkflowCoordinator.IntegrationTests
             Assert.AreEqual(correlationId, _startDbAssessmentSaga.Data.CorrelationId);
             Assert.AreEqual(_sdocId, _startDbAssessmentSaga.Data.SourceDocumentId);
             Assert.AreEqual(_processId, _startDbAssessmentSaga.Data.ProcessId);
+        }
+
+        [TearDown]
+        public void CleanupTests()
+        {
+            //TODO: Remove K2 workflow instance using _processId
+            //TODO: Remove WorkflowInstance record from WorkflowInstance table using _processId
         }
 
         private int RandomiseSdcoId()

--- a/src/WorkflowCoordinator.IntegrationTests/StartDbAssessmentSagaTests.cs
+++ b/src/WorkflowCoordinator.IntegrationTests/StartDbAssessmentSagaTests.cs
@@ -1,0 +1,71 @@
+using Common.Helpers;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+using NServiceBus.Testing;
+
+using NUnit.Framework;
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using WorkflowCoordinator.Config;
+using WorkflowCoordinator.HttpClients;
+using WorkflowCoordinator.Messages;
+using WorkflowCoordinator.Sagas;
+
+using WorkflowDatabase.EF;
+
+namespace WorkflowCoordinator.IntegrationTests
+{
+    public class StartDbAssessmentSagaTests
+    {
+        private StartDbAssessmentSaga _startDbAssessmentSaga;
+        private TestableMessageHandlerContext _handlerContext;
+        private WorkflowDbContext _dbContext;
+        private GeneralConfig _generalConfig;
+
+        [SetUp]
+        public void Setup()
+        { 
+            var configurationRoot = AzureAppConfigConfigurationRoot.Instance;
+
+            _generalConfig = new GeneralConfig();
+            configurationRoot.GetSection("k2").Bind(_generalConfig);
+            configurationRoot.GetSection("apis").Bind(_generalConfig);
+
+
+            IOptionsSnapshot<GeneralConfig> generalConfigOptions = new OptionsSnapshotWrapper<GeneralConfig>(_generalConfig);
+
+            _handlerContext = new TestableMessageHandlerContext();
+
+            var dataServiceApiClient = new DataServiceApiClient(new HttpClient(), generalConfigOptions);
+            var workflowServiceApiClient = new WorkflowServiceApiClient(new HttpClient(), generalConfigOptions);
+
+            _startDbAssessmentSaga = new StartDbAssessmentSaga(generalConfigOptions, dataServiceApiClient, workflowServiceApiClient, _dbContext);
+        }
+
+        [Test]
+        public async Task Test1()
+        {
+            // Given
+
+            var correlationId = Guid.NewGuid();
+            var sourceDocumentId = 12345678;
+            var startDbAssessmentCommand = new StartDbAssessmentCommand
+            {
+                CorrelationId = correlationId,
+                SourceDocumentId = sourceDocumentId
+            };
+
+            //When
+            await _startDbAssessmentSaga.Handle(startDbAssessmentCommand, _handlerContext);
+
+            //Then
+            Assert.AreEqual(correlationId, _startDbAssessmentSaga.Data.CorrelationId);
+            Assert.AreEqual(sourceDocumentId, _startDbAssessmentSaga.Data.SourceDocumentId);
+        }
+    }
+}

--- a/src/WorkflowCoordinator.IntegrationTests/StartDbAssessmentSagaTests.cs
+++ b/src/WorkflowCoordinator.IntegrationTests/StartDbAssessmentSagaTests.cs
@@ -135,7 +135,7 @@ namespace WorkflowCoordinator.IntegrationTests
                     new HttpClientHandler()
                     {
                         ServerCertificateCustomValidationCallback = (message, certificate2, arg3, arg4) => true,
-                        Credentials = new NetworkCredential(startupSecretsConfig.NsbToK2ApiUsername, startupSecretsConfig.NsbToK2ApiPassword)
+                        Credentials = new NetworkCredential(startupSecretsConfig.K2RestApiUsername, startupSecretsConfig.K2RestApiPassword)
                     }
                 ), generalConfigOptions, uriConfig);
         }

--- a/src/WorkflowCoordinator.IntegrationTests/WorkflowCoordinator.IntegrationTests.csproj
+++ b/src/WorkflowCoordinator.IntegrationTests/WorkflowCoordinator.IntegrationTests.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
+    <PackageReference Include="NServiceBus.Testing" Version="7.1.0" />
+    <PackageReference Include="nunit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Common.Helpers\Common.Helpers.csproj" />
+    <ProjectReference Include="..\WorkflowCoordinator\WorkflowCoordinator\WorkflowCoordinator.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/WorkflowCoordinator.IntegrationTests/WorkflowCoordinator.IntegrationTests.csproj
+++ b/src/WorkflowCoordinator.IntegrationTests/WorkflowCoordinator.IntegrationTests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="5.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
     <PackageReference Include="NServiceBus.Testing" Version="7.1.0" />
     <PackageReference Include="nunit" Version="3.11.0" />

--- a/src/WorkflowCoordinator/WorkflowCoordinator.UnitTests/StartDbAssessmentSagaTests.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator.UnitTests/StartDbAssessmentSagaTests.cs
@@ -1,16 +1,23 @@
+using AutoMapper;
+
+using FakeItEasy;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+using NServiceBus.Testing;
+
+using NUnit.Framework;
+
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using AutoMapper;
-using FakeItEasy;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Options;
-using NServiceBus.Testing;
-using NUnit.Framework;
+
 using WorkflowCoordinator.Config;
 using WorkflowCoordinator.HttpClients;
 using WorkflowCoordinator.Messages;
 using WorkflowCoordinator.Sagas;
+
 using WorkflowDatabase.EF;
 
 namespace WorkflowCoordinator.UnitTests
@@ -22,7 +29,7 @@ namespace WorkflowCoordinator.UnitTests
         private IWorkflowServiceApiClient _fakeWorkflowServiceApiClient;
         private TestableMessageHandlerContext _handlerContext;
         private WorkflowDbContext _dbContext;
-        private IMapper _mapper;
+        private IMapper _fakeMapper;
 
         [SetUp]
         public void Setup()
@@ -39,14 +46,15 @@ namespace WorkflowCoordinator.UnitTests
 
             _fakeDataServiceApiClient = A.Fake<IDataServiceApiClient>();
             _fakeWorkflowServiceApiClient = A.Fake<IWorkflowServiceApiClient>();
+            _fakeMapper = A.Fake<IMapper>();
+
             _saga = new StartDbAssessmentSaga(generalConfigOptionsSnapshot,
                 _fakeDataServiceApiClient,
                 _fakeWorkflowServiceApiClient,
                 _dbContext,
-                _mapper)
+                _fakeMapper)
             { Data = new StartDbAssessmentSagaData() };
             _handlerContext = new TestableMessageHandlerContext();
-            _mapper = A.Fake<IMapper>();
         }
 
         [Test]

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Config/StartupSecretsConfig.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Config/StartupSecretsConfig.cs
@@ -3,10 +3,10 @@
     public class StartupSecretsConfig
     {
 
-        public string NsbToK2ApiUsername { get; set; }
+        public string K2RestApiUsername { get; set; }
 
 
-        public string NsbToK2ApiPassword { get; set; }
+        public string K2RestApiPassword { get; set; }
 
     }
 }

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Config/UriConfig.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Config/UriConfig.cs
@@ -13,6 +13,7 @@ namespace WorkflowCoordinator.Config
         public Uri K2WebServiceBaseUri { get; set; }
         public Uri K2WebServiceGetWorkflowsUri { get; set; }
         public Uri K2WebServiceStartWorkflowInstanceUri { get; set; }
+        public Uri K2WebServiceTerminateWorkflowInstanceUri { get; set; }
         public Uri K2WebServiceGetTasksUri { get; set; }
 
         public Uri BuildDataServicesUri(string callerCode, int sdocId)

--- a/src/WorkflowCoordinator/WorkflowCoordinator/HttpClients/IWorkflowServiceApiClient.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/HttpClients/IWorkflowServiceApiClient.cs
@@ -7,5 +7,6 @@ namespace WorkflowCoordinator.HttpClients
         Task<int> CreateWorkflowInstance(int dbAssessmentWorkflowId);
         Task<int> GetDBAssessmentWorkflowId();
         Task<string> GetWorkflowInstanceSerialNumber(int workflowInstanceId);
+        Task TerminateWorkflowInstance(string serialNumber);
     }
 }

--- a/src/WorkflowCoordinator/WorkflowCoordinator/HttpClients/WorkflowServiceApiClient.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/HttpClients/WorkflowServiceApiClient.cs
@@ -96,5 +96,21 @@ namespace WorkflowCoordinator.HttpClients
 
             return task.SerialNumber;
         }
+
+        public async Task TerminateWorkflowInstance(string serialNumber)
+        {
+            var fullUri = new Uri(_uriConfig.Value.K2WebServiceBaseUri,
+                $"{_uriConfig.Value.K2WebServiceGetTasksUri}{serialNumber}/{_uriConfig.Value.K2WebServiceTerminateWorkflowInstanceUri}");
+            var data = "";
+
+            using (var response = await _httpClient.PostAsync(fullUri, null))
+            {
+                if (!response.IsSuccessStatusCode)
+                    throw new ApplicationException($"StatusCode='{response.StatusCode}'," +
+                                                   $"\n Message= '{data}'," +
+                                                   $"\n Url='{fullUri}'");
+            }
+
+        }
     }
 }

--- a/src/WorkflowCoordinator/WorkflowCoordinator/HttpClients/WorkflowServiceApiClient.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/HttpClients/WorkflowServiceApiClient.cs
@@ -36,7 +36,7 @@ namespace WorkflowCoordinator.HttpClients
             {
                 data = await response.Content.ReadAsStringAsync();
 
-                if (response.StatusCode != HttpStatusCode.OK)
+                if (!response.IsSuccessStatusCode)
                     throw new ApplicationException($"StatusCode='{response.StatusCode}'," +
                                                    $"\n Message= '{data}'," +
                                                    $"\n Url='{fullUri}'");
@@ -62,7 +62,7 @@ namespace WorkflowCoordinator.HttpClients
             {
                 data = await response.Content.ReadAsStringAsync();
 
-                if (response.StatusCode != HttpStatusCode.OK)
+                if (!response.IsSuccessStatusCode)
                     throw new ApplicationException($"StatusCode='{response.StatusCode}'," +
                                                    $"\n Message= '{data}'," +
                                                    $"\n Url='{fullUri}'");
@@ -84,7 +84,7 @@ namespace WorkflowCoordinator.HttpClients
             {
                 data = await response.Content.ReadAsStringAsync();
 
-                if (response.StatusCode != HttpStatusCode.OK)
+                if (!response.IsSuccessStatusCode)
                     throw new ApplicationException($"StatusCode='{response.StatusCode}'," +
                                                    $"\n Message= '{data}'," +
                                                    $"\n Url='{fullUri}'");

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Program.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Program.cs
@@ -118,7 +118,7 @@ namespace WorkflowCoordinator
                     .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler()
                     {
                         ServerCertificateCustomValidationCallback = (message, certificate2, arg3, arg4) => true,
-                        Credentials = new NetworkCredential(startupSecretConfig.NsbToK2ApiUsername, startupSecretConfig.NsbToK2ApiPassword)
+                        Credentials = new NetworkCredential(startupSecretConfig.K2RestApiUsername, startupSecretConfig.K2RestApiPassword)
                     });
 
                 UpdateableServiceProvider container = null;


### PR DESCRIPTION
### WorkflowCoordinator.IntegrationTests
- Create project
- Create StartDbAssessmentSagaTests

### WorkflowCoordinator
- Add Terminate Workflow Instance to WorkflowServiceApiClient
- Rename NsbToK2ApiUsername & NsbToK2ApiPassword config keys to
 K2RestApiUsername & K2RestApiPassword respectively
_(changed to reflect the fact that we will be using the same K2 REST account across all services)_
- Add K2WebServiceTerminateWorkflowInstanceUri config key
_(used to construct the K2 Workflow REST API Terminate Workflow Instance URI)_

### Common.Helpers
- Add OptionsSnapshotWrapper
_(to provide an easy way to instantiate an IOptionsSnapshot)_

### DataServices
- Add launchSettings
_(so port numbers will be correct)_