### PR TITLE
Update Portal Client Side Libraries

### DIFF
--- a/src/Portal/Portal/libman.json
+++ b/src/Portal/Portal/libman.json
@@ -3,7 +3,7 @@
   "defaultProvider": "cdnjs",
   "libraries": [
     {
-      "library": "jquery@3.3.1",
+      "library": "jquery@3.4.1",
       "destination": "wwwroot/lib/jquery/",
       "files": [
         "jquery.min.js",
@@ -12,7 +12,7 @@
       ]
     },
     {
-      "library": "jquery-validation-unobtrusive@3.2.9",
+      "library": "jquery-validation-unobtrusive@3.2.11",
       "destination": "wwwroot/lib/jquery-validation-unobtrusive/",
       "files": [
         "jquery.validate.unobtrusive.min.js",
@@ -20,7 +20,7 @@
       ]
     },
     {
-      "library": "jquery-validate@1.17.0",
+      "library": "jquery-validate@1.19.1",
       "destination": "wwwroot/lib/jquery-validate/",
       "files": [
         "jquery.validate.min.js",
@@ -89,7 +89,7 @@
       ]
     },
     {
-      "library": "font-awesome@5.9.0",
+      "library": "font-awesome@5.10.2",
       "destination": "wwwroot/lib/font-awesome/",
       "files": [
         "css/all.min.css",


### PR DESCRIPTION
- Update Portal Client Side Libraries
  - jquery from 3.3.1 to 3.4.1
  Thanks @tomling for reporting the security vulnerability with 3.3.1!
  - jquery-validation-unobtrusive from 3.2.9 to 3.2.11
  - jquery-validate from 1.17.0 to 1.19.1
  - font-awesome from 5.9.0 to 5.10.2