### PR TITLE
Specify schema for Oracle view

### DIFF
--- a/src/DataServices/DataServices.Models/DocumentAssessmentData.cs
+++ b/src/DataServices/DataServices.Models/DocumentAssessmentData.cs
@@ -20,7 +20,7 @@ namespace DataServices.Models
     /// 
     /// </summary>
     [DataContract]
-    [Table("SEL_HPD_TASK")]
+    [Table("SEL_HPD_TASK", Schema = "CPSRB")]
     public partial class DocumentAssessmentData : IEquatable<DocumentAssessmentData>
     { 
         /// <summary>

--- a/src/DataServices/DataServices/Models/SdraDbContext.cs
+++ b/src/DataServices/DataServices/Models/SdraDbContext.cs
@@ -8,7 +8,7 @@ namespace DataServices.Models
             : base(options)
         {
         }
-        
+
         public DbSet<DocumentAssessmentData> AssessmentData { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/src/DataServices/DataServices/Startup.cs
+++ b/src/DataServices/DataServices/Startup.cs
@@ -67,7 +67,6 @@ namespace DataServices
 
             services.AddOptions<Settings>().Bind(Configuration.GetSection("urls"));
 
-
             var startupSecrets = new StartupSecretsConfig();
             Configuration.GetSection("SdraDbSection").Bind(startupSecrets);
 


### PR DESCRIPTION
We are going to use an Oracle DB user created specifically for TM, so ensure the SDRA view is prefixed with the correct schema for any EF operations.