### PR TITLE
Fix Dataservices API in Azure

### DIFF
--- a/src/Common.Helpers/ConfigHelpers.cs
+++ b/src/Common.Helpers/ConfigHelpers.cs
@@ -9,6 +9,7 @@ namespace Common.Helpers
         public static bool IsLocalDevelopment => EnvironmentName.Equals("LocalDevelopment", StringComparison.OrdinalIgnoreCase);
 
         public static bool IsAzureDevOpsBuild => EnvironmentName.Equals("AzureDevOpsBuild", StringComparison.OrdinalIgnoreCase);
+        public static bool IsAzureDevelopment => EnvironmentName.Equals("AzureDevelopment", StringComparison.OrdinalIgnoreCase);
 
         public static bool IsAzure =>
             EnvironmentName.Equals("Azure", StringComparison.OrdinalIgnoreCase);

--- a/src/DataServices/DataServices/DataServices.csproj
+++ b/src/DataServices/DataServices/DataServices.csproj
@@ -5,6 +5,7 @@
     <LangVersion>latest</LangVersion>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <AspNetCoreModuleName>AspNetCoreModuleV2</AspNetCoreModuleName>
+    <EnableMSDeployAppOffline>true</EnableMSDeployAppOffline>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,7 +22,7 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="2.0.0-preview-009470001-1371" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.2.5" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.9" />
     <PackageReference Include="Oracle.EntityFrameworkCore" Version="2.19.30" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />

--- a/src/DataServices/DataServices/Startup.cs
+++ b/src/DataServices/DataServices/Startup.cs
@@ -34,7 +34,6 @@ namespace DataServices
     public class Startup
     {
         private readonly IHostingEnvironment _hostingEnv;
-        private readonly ILogger _logger;
 
         private IConfiguration Configuration { get; }
 
@@ -43,10 +42,9 @@ namespace DataServices
         /// </summary>
         /// <param name="env"></param>
         /// <param name="configuration"></param>
-        public Startup(IHostingEnvironment env, IConfiguration configuration, ILogger logger)
+        public Startup(IHostingEnvironment env, IConfiguration configuration)
         {
             _hostingEnv = env;
-            _logger = logger;
             Configuration = configuration;
         }
 

--- a/src/DataServices/DataServices/Startup.cs
+++ b/src/DataServices/DataServices/Startup.cs
@@ -9,12 +9,14 @@
  */
 
 using System.IO;
+using Common.Helpers;
 using DataServices.Adapters;
 using DataServices.Config;
 using DataServices.Filters;
 using DataServices.Models;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -32,6 +34,7 @@ namespace DataServices
     public class Startup
     {
         private readonly IHostingEnvironment _hostingEnv;
+        private readonly ILogger _logger;
 
         private IConfiguration Configuration { get; }
 
@@ -40,9 +43,10 @@ namespace DataServices
         /// </summary>
         /// <param name="env"></param>
         /// <param name="configuration"></param>
-        public Startup(IHostingEnvironment env, IConfiguration configuration)
+        public Startup(IHostingEnvironment env, IConfiguration configuration, ILogger logger)
         {
             _hostingEnv = env;
+            _logger = logger;
             Configuration = configuration;
         }
 
@@ -52,9 +56,9 @@ namespace DataServices
         /// <param name="services"></param>
         public void ConfigureServices(IServiceCollection services)
         {
-            // Add framework services.
             services
                 .AddMvc()
+                .SetCompatibilityVersion(CompatibilityVersion.Version_2_2)
                 .AddJsonOptions(opts =>
                 {
                     opts.SerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
@@ -125,7 +129,7 @@ namespace DataServices
                     c.SwaggerEndpoint("/swagger-original.json", "SDRA API Original");
                 });
 
-            if (env.IsDevelopment())
+            if (ConfigHelpers.IsLocalDevelopment || ConfigHelpers.IsAzureDevelopment)
             {
                 app.UseDeveloperExceptionPage();
             }


### PR DESCRIPTION
- Upgrade Microsoft.Extensions.Logging.AzureAppServices 2.1.1 to 2.2.5 (missed in the Core 2.2 upgrade).

Additional changes:

- Added EnableMSDeployAppOffline to prevent deployment errors. Particularly noticable when publishing from VS during development. We need to look at deployment slots moving forward: https://docs.microsoft.com/en-gb/azure/app-service/deploy-staging-slots#custom-warm-up-before-swap
- Added .SetCompatibilityVersion(CompatibilityVersion.Version_2_2) in Startup else it defaults to 2.0 and given we are developing a new appication in 2.2 we do not need to avoid breaking changes in 2.1/2.2.
- Added ConfigHelpers.IsAzureDevelopment and via this enabled developer exception pages in Azure Dev