### PR TITLE
Add the viewing and adding of comments to Review page

### DIFF
--- a/src/Portal.TestAutomation.Specs/Data/TasksSeedData.json
+++ b/src/Portal.TestAutomation.Specs/Data/TasksSeedData.json
@@ -10,11 +10,15 @@
     "comment": [
       {
         "processId": 123,
-        "text": "A comment"
+        "text": "A comment",
+        "username": "Ross",
+        "created": "2019-01-01T00:00:00"
       },
       {
         "processId": 123,
-        "text": "A 2nd comment"
+        "text": "A 2nd comment",
+        "username": "Bon",
+        "created": "2019-09-09T00:00:00"
       }
     ],
     "assessmentData": {
@@ -49,11 +53,15 @@
     "comment": [
       {
         "processId": 321,
-        "text": "A comment"
+        "text": "A comment",
+        "username": "Ross",
+        "created": "2019-01-01T00:00:00"
       },
       {
         "processId": 321,
-        "text": "A 2nd comment"
+        "text": "A 2nd comment",
+        "username": "Pedro",
+        "created": "2019-11-01T00:00:00"
       }
     ],
     "assessmentData": {

--- a/src/Portal/Portal/Pages/DbAssessment/Review.cshtml
+++ b/src/Portal/Portal/Pages/DbAssessment/Review.cshtml
@@ -1,11 +1,11 @@
 ﻿@page
+@using Microsoft.AspNetCore.Identity.UI.Pages.Internal
 @model Portal.Pages.DbAssessment.ReviewModel
 @{
     ViewData["Title"] = "Review";
 }
-@section Scripts{
-    <script type="text/javascript" src="~/js/Review.js"></script>
-}
+
+<script type="text/javascript" src="~/js/Review.js"></script>
 
 <div class="row" style="padding-top: 5px">
     <div class="col-lg-3 col-md-4 col-sm-4 col-xs-4">

--- a/src/Portal/Portal/Pages/DbAssessment/Review.cshtml
+++ b/src/Portal/Portal/Pages/DbAssessment/Review.cshtml
@@ -3,6 +3,9 @@
 @{
     ViewData["Title"] = "Review";
 }
+@section Scripts{
+    <script type="text/javascript" src="~/js/Review.js"></script>
+}
 
 <div class="row" style="padding-top: 5px">
     <div class="col-lg-3 col-md-4 col-sm-4 col-xs-4">
@@ -24,6 +27,7 @@
         </div>
     </div>
     <div class="col-lg-12"><hr /></div>
+    <input type="hidden" id="hdnProcessId" value="@Model.ProcessId" />
 
     <br />
 
@@ -49,5 +53,6 @@
     <br />
     @await Html.PartialAsync("_AssignTask", Model.AssignTaskModel).ConfigureAwait(false)
     <br />
-    @await Html.PartialAsync("_Comments", Model.CommentsModel).ConfigureAwait(false)
+    <div id="existingComments"></div>
+    <div id="AddCommentError"></div>
 </div>

--- a/src/Portal/Portal/Pages/DbAssessment/Review.cshtml
+++ b/src/Portal/Portal/Pages/DbAssessment/Review.cshtml
@@ -4,41 +4,41 @@
     ViewData["Title"] = "Review";
 }
 
-    <div class="row" style="padding-top: 5px">
-        <div class="col-lg-3 col-md-4 col-sm-4 col-xs-4">
-            <a asp-page="/Index">
-                <img id="ukhoLogo" src="~/images/ukhologo.svg" class="img-responsive" alt="UKHO Logo" />
-            </a>
-        </div>
+<div class="row" style="padding-top: 5px">
+    <div class="col-lg-3 col-md-4 col-sm-4 col-xs-4">
+        <a asp-page="/Index">
+            <img id="ukhoLogo" src="~/images/ukhologo.svg" class="img-responsive" alt="UKHO Logo" />
+        </a>
+    </div>
 
-        <div class="col-lg-9 col-md-8 col-sm-8 col-xs-8">
-            <div class="row">
-                <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6">
-                    <div class="pull-right">
-                        <h1>DB Assessment</h1>
-                    </div>
-                </div>
-                <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6">
-                    <div class="pull-right"><h1>Review</h1></div>
+    <div class="col-lg-9 col-md-8 col-sm-8 col-xs-8">
+        <div class="row">
+            <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6">
+                <div class="pull-right">
+                    <h1>DB Assessment</h1>
                 </div>
             </div>
-        </div>
-        <div class="col-lg-12"><hr /></div>
-
-        <br />
-
-        <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
-            <div class="row">
-                <div class="pull-right">
-                    <button id="btnPutOnHold" class="btn btn-primary"><span style="padding-right: 5px;"></span>Put On Hold</button>
-                    <button id="btnTerminate" class="btn btn-primary"><span style="padding-right: 5px;"></span>Terminate</button>
-                    <input id="btnClose" type="button" class="btn btn-primary" value="Close" onclick="window.location.href='/Index'"/>
-                    <button id="btnSave" class="btn btn-primary"><span style="padding-right: 5px;"></span>Save</button>
-                    <button id="btnDone" class="btn btn-primary"><span style="padding-right: 5px;"></span>Done</button>
-                </div>
+            <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6">
+                <div class="pull-right"><h1>Review</h1></div>
             </div>
         </div>
     </div>
+    <div class="col-lg-12"><hr /></div>
+
+    <br />
+
+    <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
+        <div class="row">
+            <div class="pull-right">
+                <button id="btnPutOnHold" class="btn btn-primary"><span style="padding-right: 5px;"></span>Put On Hold</button>
+                <button id="btnTerminate" class="btn btn-primary"><span style="padding-right: 5px;"></span>Terminate</button>
+                <input id="btnClose" type="button" class="btn btn-primary" value="Close" onclick="window.location.href='/Index'" />
+                <button id="btnSave" class="btn btn-primary"><span style="padding-right: 5px;"></span>Save</button>
+                <button id="btnDone" class="btn btn-primary"><span style="padding-right: 5px;"></span>Done</button>
+            </div>
+        </div>
+    </div>
+</div>
 
 <br />
 

--- a/src/Portal/Portal/Pages/DbAssessment/Review.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/Review.cshtml.cs
@@ -62,6 +62,7 @@ namespace Portal.Pages.DbAssessment
         public IActionResult OnGetCommentsPartial(string comment, int processId)
         {
             // TODO: Test with Azure
+            // TODO: This will not work in Azure; need alternative; but will work in local dev
             var userId = _httpContextAccessor.HttpContext.User.Identity.Name;
 
             DbContext.Comment.Add(new Comments
@@ -69,7 +70,7 @@ namespace Portal.Pages.DbAssessment
                 ProcessId = processId,
                 WorkflowInstanceId = DbContext.WorkflowInstance.First(c => c.ProcessId == processId).WorkflowInstanceId,
                 Created = DateTime.Now,
-                Username = userId == string.Empty ? "Unknown" : userId,
+                Username = string.IsNullOrEmpty(userId) ? "Unknown" : userId,
                 Text = comment
             });
 

--- a/src/Portal/Portal/Pages/DbAssessment/_Comments.cshtml
+++ b/src/Portal/Portal/Pages/DbAssessment/_Comments.cshtml
@@ -1,34 +1,46 @@
-﻿@using WorkflowDatabase.EF.Models
-@model Portal.Pages.DbAssessment._CommentsModel
+﻿@model Portal.Pages.DbAssessment._CommentsModel
 @*
     For more information on enabling MVC for empty projects, visit http://go.microsoft.com/fwlink/?LinkID=397860
 *@
+
+@section scripts
+{
+    <script type="text/javascript" src="~/js/Comments.js"></script>
+}
+
+@{
+    Layout = "Shared/_Layout";
+}
+
 <div class="panel panel-default">
     <div class="panel-heading">
         <span>Comments</span>
     </div>
     <div class="panel-body">
-        @foreach (var example in Model.Comments)
+        @if (Model != null && Model.Comments != null)
         {
-            <article>
-                <div class="col-xs-6">
-                    <div class="pull-left">
-                        @example.Username
+            @foreach (var comment in Model.Comments)
+            {
+                <article>
+                    <div class="col-xs-6">
+                        <div class="pull-left">
+                            @comment.Username
+                        </div>
                     </div>
-                </div>
-                <div class="col-xs-6">
-                    <div class="pull-right" style="padding-right: 50px;">
-                        @example.Created.ToString("M")
+                    <div class="col-xs-6">
+                        <div class="pull-right" style="padding-right: 50px;">
+                            @comment.Created.ToString("M")
+                        </div>
                     </div>
-                </div>
-                <div class="col-lg-12">
-                    <p>
-                        @example.Text
-                    </p>
-                    <hr />
-                </div>
-            </article>
-            <br />
+                    <div class="col-lg-12">
+                        <p>
+                            @comment.Text
+                        </p>
+                        <hr />
+                    </div>
+                </article>
+                <br />
+            }
         }
         <button id="btnAddComment" class="btn btn-primary" data-toggle="modal" data-target="#addCommentModal"><span style="padding-right: 5px;"></span>Add Comments</button>
 
@@ -43,20 +55,19 @@
                         @Html.AntiForgeryToken()
                         <div class="modal-body">
                             <div id="OUmodal-body">
-                                <input type="hidden" id="hdnProcessId" value="@Model.ProcessId" name="processId"/>
                                 <textarea style="height: 100px;" id="txtComment" name="comment" class="form-control"></textarea>
-                                <br/>
+                                <input type="hidden" id="hdnProcessId" value="@Model.ProcessId" />
+                                <br />
                                 <div id="AddCommentError"></div>
                             </div>
                         </div>
                         <div class="modal-footer">
-                            <input type="submit" id="btnPostComment" accesskey="a" class="btn btn-success" data-toggle="tooltip" data-placement="left" title="Submit comment" value="Add comment" asp-page-handler="NewComment" />
+                            <button type="button" id="btnPostComment" accesskey="a" class="btn btn-success" data-toggle="tooltip" data-placement="left" title="Submit comment">Add comment</button>
                             <button type="button" id="btnCloseComment" class="btn btn-default" accesskey="c" data-dismiss="modal" data-toggle="tooltip" data-placement="left" title="Close this popup">Close</button>
                         </div>
                     </form>
                 </div>
             </div>
         </div>
-
     </div>
 </div>

--- a/src/Portal/Portal/Pages/DbAssessment/_Comments.cshtml
+++ b/src/Portal/Portal/Pages/DbAssessment/_Comments.cshtml
@@ -3,14 +3,7 @@
     For more information on enabling MVC for empty projects, visit http://go.microsoft.com/fwlink/?LinkID=397860
 *@
 
-@section scripts
-{
-    <script type="text/javascript" src="~/js/Comments.js"></script>
-}
-
-@{
-    Layout = "Shared/_Layout";
-}
+<script type="text/javascript" src="~/js/Comments.js"></script>
 
 <div class="panel panel-default">
     <div class="panel-heading">
@@ -51,21 +44,18 @@
                     <div class="modal-header">
                         <h4 class="modal-title">Add comment</h4>
                     </div>
-                    <form method="post">
-                        @Html.AntiForgeryToken()
-                        <div class="modal-body">
-                            <div id="OUmodal-body">
-                                <textarea style="height: 100px;" id="txtComment" name="comment" class="form-control"></textarea>
-                                <input type="hidden" id="hdnProcessId" value="@Model.ProcessId" />
-                                <br />
-                                <div id="AddCommentError"></div>
-                            </div>
+                    <div class="modal-body">
+                        <div id="modal-body">
+                            <textarea style="height: 100px;" id="txtComment" name="comment" class="form-control"></textarea>
+                            <input type="hidden" id="hdnProcessId" value="@Model.ProcessId" />
+                            <br />
+                            <div id="AddCommentError"></div>
                         </div>
-                        <div class="modal-footer">
-                            <button type="button" id="btnPostComment" accesskey="a" class="btn btn-success" data-toggle="tooltip" data-placement="left" title="Submit comment">Add comment</button>
-                            <button type="button" id="btnCloseComment" class="btn btn-default" accesskey="c" data-dismiss="modal" data-toggle="tooltip" data-placement="left" title="Close this popup">Close</button>
-                        </div>
-                    </form>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" id="btnPostComment" accesskey="a" class="btn btn-success" data-toggle="tooltip" data-placement="left" title="Submit comment">Add comment</button>
+                        <button type="button" id="btnCloseComment" class="btn btn-default" accesskey="c" data-dismiss="modal" data-toggle="tooltip" data-placement="left" title="Close this popup">Close</button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/Portal/Portal/Pages/DbAssessment/_Comments.cshtml
+++ b/src/Portal/Portal/Pages/DbAssessment/_Comments.cshtml
@@ -30,6 +30,33 @@
             </article>
             <br />
         }
-        <button id="btnAddComment" class="btn btn-primary"><span style="padding-right: 5px;"></span>Add Comments</button>
+        <button id="btnAddComment" class="btn btn-primary" data-toggle="modal" data-target="#addCommentModal"><span style="padding-right: 5px;"></span>Add Comments</button>
+
+        @* Modal Add new comment *@
+        <div class="modal fade" id="addCommentModal" tabindex="-1" role="dialog" aria-labelledby="AddComment" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h4 class="modal-title">Add comment</h4>
+                    </div>
+                    <form method="post">
+                        @Html.AntiForgeryToken()
+                        <div class="modal-body">
+                            <div id="OUmodal-body">
+                                <input type="hidden" id="hdnProcessId" value="@Model.ProcessId" name="processId"/>
+                                <textarea style="height: 100px;" id="txtComment" name="comment" class="form-control"></textarea>
+                                <br/>
+                                <div id="AddCommentError"></div>
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <input type="submit" id="btnPostComment" accesskey="a" class="btn btn-success" data-toggle="tooltip" data-placement="left" title="Submit comment" value="Add comment" asp-page-handler="NewComment" />
+                            <button type="button" id="btnCloseComment" class="btn btn-default" accesskey="c" data-dismiss="modal" data-toggle="tooltip" data-placement="left" title="Close this popup">Close</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
     </div>
 </div>

--- a/src/Portal/Portal/Pages/DbAssessment/_Comments.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_Comments.cshtml.cs
@@ -13,5 +13,6 @@ namespace Portal.Pages.DbAssessment
         {
 
         }
+
     }
 }

--- a/src/Portal/Portal/Pages/DbAssessment/_Comments.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_Comments.cshtml.cs
@@ -6,6 +6,7 @@ namespace Portal.Pages.DbAssessment
 {
     public class _CommentsModel : PageModel
     {
+        public int ProcessId { get; set; }
         public List<Comments> Comments { get; set; }
 
         public void OnGet()

--- a/src/Portal/Portal/Pages/Index.cshtml
+++ b/src/Portal/Portal/Pages/Index.cshtml
@@ -70,7 +70,7 @@
                 {
                     <tr>
                         <td>
-                            <a asp-page="/dbassessment/Review">@task.ProcessId</a>
+                            <a href="/dbassessment/Review?=@task.ProcessId">@task.ProcessId</a>
                         </td>
                         <td>
                             @task.DaysToDmEndDate
@@ -160,7 +160,7 @@
 
                     <tr class="@rowColour">
                         <td>
-                            <a asp-page="/dbassessment/Review">@task.ProcessId</a>
+                            <a href="/dbassessment/Review?=@task.ProcessId">@task.ProcessId</a>
                         </td>
                         <td>
                             @task.DaysToDmEndDate

--- a/src/Portal/Portal/Pages/Shared/_Layout.cshtml
+++ b/src/Portal/Portal/Pages/Shared/_Layout.cshtml
@@ -6,17 +6,34 @@
     <title>@ViewData["Title"] - Task Manager Portal</title>
 
     <environment include="Development">
-        <link rel="stylesheet" href="~/lib/font-awesome/css/all.css" >
+        <link rel="stylesheet" href="~/lib/font-awesome/css/all.css">
         <link rel="stylesheet" href="~/lib/bootstrap/css/bootstrap.css" />
         <link rel="stylesheet" href="~/lib/datatables/css/dataTables.bootstrap.css" />
         <link rel="stylesheet" href="~/css/site.css" />
     </environment>
     <environment exclude="Development">
-        <link rel="stylesheet" href="~/lib/font-awesome/css/all.min.css" >
+        <link rel="stylesheet" href="~/lib/font-awesome/css/all.min.css">
         <link rel="stylesheet" href="~/lib/bootstrap/css/bootstrap.min.css" />
         <link rel="stylesheet" href="~/lib/datatables/css/dataTables.bootstrap.min.css" />
         <link rel="stylesheet" href="~/css/site.min.css" asp-append-version="true" />
     </environment>
+
+    <environment include="Development">
+        <script src="~/lib/jquery/jquery.js"></script>
+        <script src="~/js/site.js" asp-append-version="true"></script>
+        <script src="~/lib/bootstrap/js/bootstrap.js"></script>
+        <script src="~/lib/datatables/js/jquery.dataTables.js"></script>
+        <script src="~/lib/datatables/js/dataTables.bootstrap.js"></script>
+    </environment>
+    <environment exclude="Development">
+        <script src="~/lib/jquery/jquery.min.js"></script>
+        <script src="~/lib/bootstrap/js/bootstrap.min.js"></script>
+        <script src="~/lib/datatables/js/jquery.dataTables.min.js"></script>
+        <script src="~/lib/datatables/js/dataTables.bootstrap.min.js"></script>
+        <script src="~/js/site.min.js" asp-append-version="true"></script>
+    </environment>
+
+    @RenderSection("Scripts", required: false)
 </head>
 <body>
     <partial name="_CookieConsentPartial" />
@@ -29,22 +46,5 @@
             </div>
         </footer>
     </div>
-
-    <environment include="Development">
-        <script src="~/lib/jquery/jquery.js"></script>
-        <script src="~/lib/bootstrap/js/bootstrap.js"></script>
-        <script src="~/lib/datatables/js/jquery.dataTables.js"></script>
-        <script src="~/lib/datatables/js/dataTables.bootstrap.js"></script>
-        <script src="~/js/site.js" asp-append-version="true"></script>
-    </environment>
-    <environment exclude="Development">
-        <script src="~/lib/jquery/jquery.min.js"></script>
-        <script src="~/lib/bootstrap/js/bootstrap.min.js"></script>
-        <script src="~/lib/datatables/js/jquery.dataTables.min.js"></script>
-        <script src="~/lib/datatables/js/dataTables.bootstrap.min.js"></script>
-        <script src="~/js/site.min.js" asp-append-version="true"></script>
-    </environment>
-
-    @RenderSection("Scripts", required: false)
 </body>
 </html>

--- a/src/Portal/Portal/Startup.cs
+++ b/src/Portal/Portal/Startup.cs
@@ -48,6 +48,8 @@ namespace Portal
                 options.MinimumSameSitePolicy = SameSiteMode.None;
             });
 
+            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+
             services.AddOptions<GeneralSettings>().Bind(Configuration.GetSection("portal"));
 
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);

--- a/src/Portal/Portal/wwwroot/js/Comments.js
+++ b/src/Portal/Portal/wwwroot/js/Comments.js
@@ -2,27 +2,35 @@
 
     $("#btnPostComment").click(function () {
 
-        var jsonData = {
-            "comment": $('#txtComment').val(), "processId": $('#hdnProcessId').val()
+        if ($('#txtComment').val() === "") {
+            $("#AddCommentError")
+                .html("<div class=\"alert alert-danger\" role=\"alert\">Please enter a comment.</div>");
+            $('#txtComment').focus();
+        } else {
+
+            var jsonData = {
+                "comment": $("#txtComment").val(),
+                "processId": $("#hdnProcessId").val()
             };
 
-        $.ajax({
-            type: 'GET',
-            url: "Review/?handler=CommentsPartial",
-            beforeSend: function (xhr) {
-                xhr.setRequestHeader("XSRF-TOKEN", $('input:hidden[name="__RequestVerificationToken"]').val());
-            },
-            contentType: 'application/json; charset=utf-8"',
-            data: jsonData,
-            success: function (result) {
-                $("#existingComments").html(result);
-                $('#addCommentModal').modal('hide');
-                $('.modal-backdrop').remove();
-                $('body').removeClass('modal-open');
-            },
-            error: function (error) {
-                console.log(error);
-            }
-        });
+            $.ajax({
+                type: "GET",
+                url: "Review/?handler=CommentsPartial",
+                beforeSend: function(xhr) {
+                    xhr.setRequestHeader("XSRF-TOKEN", $('input:hidden[name="__RequestVerificationToken"]').val());
+                },
+                contentType: 'application/json; charset=utf-8"',
+                data: jsonData,
+                success: function(result) {
+                    $("#existingComments").html(result);
+                    $("#addCommentModal").modal("hide");
+                    $(".modal-backdrop").remove();
+                    $("body").removeClass("modal-open");
+                },
+                error: function(error) {
+                    console.log(error);
+                }
+            });
+        }
     });
 });

--- a/src/Portal/Portal/wwwroot/js/Comments.js
+++ b/src/Portal/Portal/wwwroot/js/Comments.js
@@ -1,0 +1,28 @@
+﻿$(document).ready(function () {
+
+    $("#btnPostComment").click(function () {
+
+        var jsonData = {
+            "comment": $('#txtComment').val(), "processId": $('#hdnProcessId').val()
+            };
+
+        $.ajax({
+            type: 'GET',
+            url: "Review/?handler=CommentsPartial",
+            beforeSend: function (xhr) {
+                xhr.setRequestHeader("XSRF-TOKEN", $('input:hidden[name="__RequestVerificationToken"]').val());
+            },
+            contentType: 'application/json; charset=utf-8"',
+            data: jsonData,
+            success: function (result) {
+                $("#existingComments").html(result);
+                $('#addCommentModal').modal('hide');
+                $('.modal-backdrop').remove();
+                $('body').removeClass('modal-open');
+            },
+            error: function (error) {
+                console.log(error);
+            }
+        });
+    });
+});

--- a/src/Portal/Portal/wwwroot/js/Review.js
+++ b/src/Portal/Portal/wwwroot/js/Review.js
@@ -1,0 +1,21 @@
+﻿$(document).ready(function () {
+
+    var processId = { "processId": $("#hdnProcessId").val() };
+
+    $.ajax({
+        type: "GET",
+        url: "Review/?handler=RetrieveComments",
+        beforeSend: function (xhr) {
+            xhr.setRequestHeader("XSRF-TOKEN", $('input:hidden[name="__RequestVerificationToken"]').val());
+        },
+        contentType: "application/json; charset=utf-8",
+        data: processId,
+        success: function (result) {
+            $("#existingComments").html(result);
+        },
+        error: function (error) {
+            $("#AddCommentError")
+                .html("<div class=\"alert alert-danger\" role=\"alert\">Failed to load comments.</div>");
+        }
+    });
+});


### PR DESCRIPTION
- On Review page load, retrieve the comments for given ProcessId and display
- 2 methods added to Review page code behind; one for comment retrieval and one to add a comment. These methods use the Razor page routing, substituting the OnGet part of the method name.
- Use HttpContextAccessor to retrieve current username. This will work locally when IISExpress is set to Windows auth, but won't work in Azure due to not running with Windows auth. Will revisit once AD sync is sorted. Currently comments added via Azure will use a user of Unknown.
- Separate .js files for Review page and _Comments partial. These use the XSRF-TOKEN to help secure against cross site request forgery.
- Tried to use JQuery's validation plugin on the comments modal, but this requires the use of a form element with an input submit button thus reloading the entire Review page. Currently using manual validation as per OWP.
- Landing page ProcessId column now a link to Review page, passing through ProcessId
- Fix automation framework comment seeded data