### PR TITLE
Handle various error scenarios when retrieving source documents

### DIFF
--- a/src/Common/Common.Messages/Commands/InitiateSourceDocumentRetrievalCommand.cs
+++ b/src/Common/Common.Messages/Commands/InitiateSourceDocumentRetrievalCommand.cs
@@ -7,5 +7,6 @@ namespace Common.Messages.Commands
         public int SourceDocumentId { get; set; }
         public Guid CorrelationId { get; set; }
         public int ProcessId { get; set; }
+        public bool GeoReferenced { get; set; }
     }
 }

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Data/TasksSeedData.json
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Data/TasksSeedData.json
@@ -10,11 +10,15 @@
     "comment": [
       {
         "processId": 123,
-        "text": "A comment"
+        "text": "A comment",
+        "username": "Ross",
+        "created": "2019-01-01T00:00:00"
       },
       {
         "processId": 123,
-        "text": "A 2nd comment"
+        "text": "A 2nd comment",
+        "username": "Ben",
+        "created": "2019-01-03T00:00:00"
       }
     ],
     "assessmentData": {
@@ -49,11 +53,15 @@
     "comment": [
       {
         "processId": 321,
-        "text": "A comment"
+        "text": "A comment",
+        "username": "G",
+        "created": "2019-02-03T00:00:00"
       },
       {
         "processId": 321,
-        "text": "A 2nd comment"
+        "text": "A 2nd comment",
+        "username": "Bon",
+        "created": "2019-01-03T00:00:00"
       }
     ],
     "assessmentData": {
@@ -88,11 +96,15 @@
     "comment": [
       {
         "processId": 125,
-        "text": "A comment"
+        "text": "A comment",
+        "username": "Samir",
+        "created": "2019-02-03T00:00:00"
       },
       {
         "processId": 125,
-        "text": "A 2nd comment"
+        "text": "A 2nd comment",
+        "username": "GW",
+        "created": "2019-11-03T00:00:00"
       }
     ],
     "assessmentData": {
@@ -127,11 +139,15 @@
     "comment": [
       {
         "processId": 126,
-        "text": "A comment"
+        "text": "A comment",
+        "username": "Peter",
+        "created": "2019-10-11T00:00:00"
       },
       {
         "processId": 126,
-        "text": "A 2nd comment"
+        "text": "A 2nd comment",
+        "username": "Shauno",
+        "created": "2019-06-12T00:00:00"
       }
     ],
     "assessmentData": {
@@ -153,6 +169,47 @@
       "activityCode": "4881",
       "assessor": "BatesP",
       "verifier": "BarzeyS"
+    }
+  },
+  {
+    "processId": 127,
+    "serialNumber": "126_sn",
+    "parentProcessId": null,
+    "workflowType": "DbAssessment",
+    "activityName": "Assess",
+    "startedAt": "2019-01-01T00:00:00",
+    "status": "Started",
+    "comment": [
+      {
+        "processId": 127,
+        "text": "A comment",
+        "username": "The Gup",
+        "created": "2019-11-09T00:00:00"
+      },
+      {
+        "processId": 127,
+        "text": "A 2nd comment",
+        "username": "Ross",
+        "created": "2019-09-12T00:00:00"
+      }
+    ],
+    "assessmentData": {
+      "sdocId": 65533,
+      "rsdraNumber": "RSDRA342130002",
+      "sourceDocumentName": "4532ss.pdf",
+      "receiptDate": "2019-07-11T00:00:00",
+      "toSdoDate": "2019-07-03T00:00:00",
+      "effectiveStartDate": "2019-07-10T00:00:00",
+      "teamDistributedTo": "HW",
+      "sourceDocumentType": "Email",
+      "sourceNature": "Aggressive",
+      "datum": null,
+      "processId": 127
+    },
+    "dbAssessmentReviewData": {
+      "processId": 127,
+      "ion": "I8766",
+      "activityCode": "4881"
     }
   }
 ]

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Enums/ClearFromQueueReturnCodeEnum.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Enums/ClearFromQueueReturnCodeEnum.cs
@@ -1,6 +1,6 @@
 ﻿namespace SourceDocumentCoordinator.Enums
 {
-    public enum ClearDocumentFromQueueReturnCodeEnum
+    public enum ClearFromQueueReturnCodeEnum
     {
         Success = 0,
         Warning = 21,

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Enums/QueueForRetrievalReturnCodeEnum.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Enums/QueueForRetrievalReturnCodeEnum.cs
@@ -1,0 +1,11 @@
+﻿namespace SourceDocumentCoordinator.Enums
+{
+    public enum QueueForRetrievalReturnCodeEnum
+    {
+        Success = 0,
+        AlreadyQueued = 1,
+        SdocIdNotRecognised = 41,
+        QueueInsertionFailed = 44
+    }
+}
+

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Enums/RequestQueueStatusReturnCodeEnum.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Enums/RequestQueueStatusReturnCodeEnum.cs
@@ -7,6 +7,7 @@
         NotGeoreferenced = 20,
         FolderNotWritable = 40,
         NotSuitableForConversion = 43,
+        QueueInsertionFailed = 44,
         ConversionFailed = 45,
         ConversionTimeOut = 46
     }

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Enums/RequestQueueStatusReturnCodeEnum.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Enums/RequestQueueStatusReturnCodeEnum.cs
@@ -1,0 +1,14 @@
+﻿namespace SourceDocumentCoordinator.Enums
+{
+    public enum RequestQueueStatusReturnCodeEnum
+    {
+        Success = 0,
+        Queued = 1,
+        NotGeoreferenced = 20,
+        FolderNotWritable = 40,
+        NotSuitableForConversion = 43,
+        ConversionFailed = 45,
+        ConversionTimeOut = 46
+    }
+}
+

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Enums/RequestQueueStatusReturnCodeEnum.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Enums/RequestQueueStatusReturnCodeEnum.cs
@@ -6,6 +6,7 @@
         Queued = 1,
         NotGeoreferenced = 20,
         FolderNotWritable = 40,
+        NoDocumentFound = 42,
         NotSuitableForConversion = 43,
         QueueInsertionFailed = 44,
         ConversionFailed = 45,

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Handlers/ClearDocumentRequestFromQueueCommandHandler.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Handlers/ClearDocumentRequestFromQueueCommandHandler.cs
@@ -40,8 +40,8 @@ namespace SourceDocumentCoordinator.Handlers
             {
                 switch (returnCode.Code.Value)
                 {
-                    case (int)ClearDocumentFromQueueReturnCodeEnum.Success:
-                    case (int)ClearDocumentFromQueueReturnCodeEnum.Warning:
+                    case (int)ClearFromQueueReturnCodeEnum.Success:
+                    case (int)ClearFromQueueReturnCodeEnum.Warning:
                         UpdateSourceDocumentStatus(message.SourceDocumentId, SourceDocumentRetrievalStatus.Complete);
                         break;
                     default:

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Sagas/SourceDocumentRetrievalSaga.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Sagas/SourceDocumentRetrievalSaga.cs
@@ -134,7 +134,6 @@ namespace SourceDocumentCoordinator.Sagas
                 
                     MarkAsComplete();
 
-                    // TODO: retry with different flag
                     var msg = new InitiateSourceDocumentRetrievalCommand
                     {
                         CorrelationId = message.CorrelationId,

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Sagas/SourceDocumentRetrievalSaga.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Sagas/SourceDocumentRetrievalSaga.cs
@@ -175,6 +175,10 @@ namespace SourceDocumentCoordinator.Sagas
                     MarkAsComplete();
                     throw new ApplicationException($"Source document folder not writeable: {Environment.NewLine}{sourceDocument.Message}{Environment.NewLine}" +
                                                    $"{message.ToJSONSerializedString()}");
+                case RequestQueueStatusReturnCodeEnum.NoDocumentFound:
+                    MarkAsComplete();
+                    throw new ApplicationException($"Cannot find source document: {Environment.NewLine}{sourceDocument.Message}{Environment.NewLine}" +
+                                                   $"{message.ToJSONSerializedString()}");
                 case RequestQueueStatusReturnCodeEnum.QueueInsertionFailed:
                     MarkAsComplete();
                     throw new ApplicationException($"Unable to queue source document for retrieval: {Environment.NewLine}{sourceDocument.Message}{Environment.NewLine}" +

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Sagas/SourceDocumentRetrievalSagaData.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Sagas/SourceDocumentRetrievalSagaData.cs
@@ -10,5 +10,6 @@ namespace SourceDocumentCoordinator.Sagas
         public Guid CorrelationId { get; set; }
         public int SourceDocumentId { get; set; }
         public int SourceDocumentStatusId { get; set; } 
+        public int ProcessId { get; set; }
     }
 }

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Data/TasksSeedData.json
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Data/TasksSeedData.json
@@ -10,11 +10,15 @@
     "comment": [
       {
         "processId": 123,
-        "text": "A comment"
+        "text": "A comment",
+        "username": "Ross",
+        "created": "2019-01-01T00:00:00"
       },
       {
         "processId": 123,
-        "text": "A 2nd comment"
+        "text": "A 2nd comment",
+        "username": "Ben",
+        "created": "2019-01-03T00:00:00"
       }
     ],
     "assessmentData": {
@@ -49,11 +53,15 @@
     "comment": [
       {
         "processId": 321,
-        "text": "A comment"
+        "text": "A comment",
+        "username": "G",
+        "created": "2019-02-03T00:00:00"
       },
       {
         "processId": 321,
-        "text": "A 2nd comment"
+        "text": "A 2nd comment",
+        "username": "Bon",
+        "created": "2019-01-03T00:00:00"
       }
     ],
     "assessmentData": {
@@ -88,11 +96,15 @@
     "comment": [
       {
         "processId": 125,
-        "text": "A comment"
+        "text": "A comment",
+        "username": "Samir",
+        "created": "2019-02-03T00:00:00"
       },
       {
         "processId": 125,
-        "text": "A 2nd comment"
+        "text": "A 2nd comment",
+        "username": "GW",
+        "created": "2019-11-03T00:00:00"
       }
     ],
     "assessmentData": {
@@ -127,11 +139,15 @@
     "comment": [
       {
         "processId": 126,
-        "text": "A comment"
+        "text": "A comment",
+        "username": "Peter",
+        "created": "2019-10-11T00:00:00"
       },
       {
         "processId": 126,
-        "text": "A 2nd comment"
+        "text": "A 2nd comment",
+        "username": "Shauno",
+        "created": "2019-06-12T00:00:00"
       }
     ],
     "assessmentData": {
@@ -153,6 +169,47 @@
       "activityCode": "4881",
       "assessor": "BatesP",
       "verifier": "BarzeyS"
+    }
+  },
+  {
+    "processId": 127,
+    "serialNumber": "126_sn",
+    "parentProcessId": null,
+    "workflowType": "DbAssessment",
+    "activityName": "Assess",
+    "startedAt": "2019-01-01T00:00:00",
+    "status": "Started",
+    "comment": [
+      {
+        "processId": 127,
+        "text": "A comment",
+        "username": "The Gup",
+        "created": "2019-11-09T00:00:00"
+      },
+      {
+        "processId": 127,
+        "text": "A 2nd comment",
+        "username": "Ross",
+        "created": "2019-09-12T00:00:00"
+      }
+    ],
+    "assessmentData": {
+      "sdocId": 65533,
+      "rsdraNumber": "RSDRA342130002",
+      "sourceDocumentName": "4532ss.pdf",
+      "receiptDate": "2019-07-11T00:00:00",
+      "toSdoDate": "2019-07-03T00:00:00",
+      "effectiveStartDate": "2019-07-10T00:00:00",
+      "teamDistributedTo": "HW",
+      "sourceDocumentType": "Email",
+      "sourceNature": "Aggressive",
+      "datum": null,
+      "processId": 127
+    },
+    "dbAssessmentReviewData": {
+      "processId": 127,
+      "ion": "I8766",
+      "activityCode": "4881"
     }
   }
 ]

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Sagas/StartDbAssessmentSaga.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Sagas/StartDbAssessmentSaga.cs
@@ -84,15 +84,14 @@ namespace WorkflowCoordinator.Sagas
                 WorkflowInstanceId = workflowInstanceId.Value
             });
 
-            // TODO: Fire InitiateSourceDocumentRetrievalCommand to SourceDocumentCoordinator to retrieve the Document
-            // TODO: Add InitiateSourceDocumentRetrievalCommand handler in SourceDocumentCoordinator to start document retrieval process
             log.Debug($"Sending {nameof(InitiateSourceDocumentRetrievalCommand)}");
 
             var initiateRetrievalCommand = new InitiateSourceDocumentRetrievalCommand()
             {
                 CorrelationId = Data.CorrelationId,
                 ProcessId = Data.ProcessId,
-                SourceDocumentId = Data.SourceDocumentId
+                SourceDocumentId = Data.SourceDocumentId,
+                GeoReferenced = true
             };
 
             await context.Send(initiateRetrievalCommand).ConfigureAwait(false);

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Sagas/StartDbAssessmentSaga.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Sagas/StartDbAssessmentSaga.cs
@@ -111,7 +111,9 @@ namespace WorkflowCoordinator.Sagas
             log.Debug($"Handling {nameof(RetrieveAssessmentDataCommand)}: {message.ToJSONSerializedString()}");
 
             // Call DataServices to get the assessment data for the given sdoc Id
-            var assessmentData = await _dataServiceApiClient.GetAssessmentData(_generalConfig.Value.CallerCode, message.SourceDocumentId);
+            var assessmentData =
+                await _dataServiceApiClient.GetAssessmentData(_generalConfig.Value.CallerCode,
+                    message.SourceDocumentId);
 
             // Add assessment data and any comments to DB, after auto mapping it
             var mappedAssessmentData = _mapper.Map<DocumentAssessmentData, AssessmentData>(assessmentData);
@@ -120,6 +122,10 @@ namespace WorkflowCoordinator.Sagas
             mappedAssessmentData.ProcessId = message.ProcessId;
             mappedComments.WorkflowInstanceId = message.WorkflowInstanceId;
             mappedComments.ProcessId = message.ProcessId;
+
+            // TODO: Exception triggered due to Created and Username not being populated
+            mappedComments.Created = DateTime.Now;
+            mappedComments.Username = string.Empty;
 
             _dbContext.AssessmentData.Add(mappedAssessmentData);
 


### PR DESCRIPTION
- Add QueueForRetrievalReturnCodeEnum to hold potential returned error code values when requesting a source document
- Add ClearFromQueueReturnCodeEnum to hold potential returned error code values when checking source doc queue retrieval status
- Add methods to process the return codes from the above and throw exception if a code is returned that we haven't coded for
- In specific error cases, re-request the source document without requesting geotiff conversion
- Add unit tests for the above
- Add username and created values to comments in seeded data