### PR TITLE
Automation to ensure source document is displayed on Review page

### DIFF
--- a/src/Portal.TestAutomation.Framework/ContextClasses/WorkflowInstanceContext.cs
+++ b/src/Portal.TestAutomation.Framework/ContextClasses/WorkflowInstanceContext.cs
@@ -1,0 +1,7 @@
+﻿namespace Portal.TestAutomation.Framework.ContextClasses
+{
+    public class WorkflowInstanceContext
+    {
+        public int ProcessId { get; set; }
+    }
+}

--- a/src/Portal.TestAutomation.Framework/Hooks/BaseHooks.cs
+++ b/src/Portal.TestAutomation.Framework/Hooks/BaseHooks.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using OpenQA.Selenium;
+﻿using OpenQA.Selenium;
 using TechTalk.SpecFlow;
 
 namespace Portal.TestAutomation.Framework.Hooks

--- a/src/Portal.TestAutomation.Framework/Pages/LandingPage.cs
+++ b/src/Portal.TestAutomation.Framework/Pages/LandingPage.cs
@@ -21,6 +21,7 @@ namespace Portal.TestAutomation.Framework.Pages
         private IWebElement UnassignedTaskTable => _driver.FindElement(By.Id("unassignedTasks"));
         private IWebElement AssignedTaskTable => _driver.FindElement(By.Id("inFlightTasks"));
         private IWebElement GlobalSearchField => _driver.FindElement(By.Id("txtGlobalSearch"));
+        private IWebElement ClickOnTask => _driver.FindElement(By.XPath("//*[@id='inFlightTasks']/tbody/tr[1]/td[1]/a"));
         private List<IWebElement> UnassignedTaskTableRows => UnassignedTaskTable.FindElements(By.TagName("tr")).ToList();
         private List<IWebElement> AssignedTaskTableRows => AssignedTaskTable.FindElements(By.TagName("tr")).ToList();
 
@@ -72,6 +73,11 @@ namespace Portal.TestAutomation.Framework.Pages
             // Checks both unassigned and assigned tables for correct process id
             return UnassignedTaskTableRows[1].FindElements(By.TagName("td")).Count != 0 && int.Parse(UnassignedTaskTableRows[1].FindElements(By.TagName("td"))[0].Text) == processId
                    && AssignedTaskTableRows[1].FindElements(By.TagName("td")).Count != 0 && int.Parse(AssignedTaskTableRows[1].FindElements(By.TagName("td"))[0].Text) == processId;
+        }
+
+        public void SelectAssessment()
+        {
+            ClickOnTask.Click();
         }
     }
 }

--- a/src/Portal.TestAutomation.Framework/Pages/LandingPage.cs
+++ b/src/Portal.TestAutomation.Framework/Pages/LandingPage.cs
@@ -74,10 +74,5 @@ namespace Portal.TestAutomation.Framework.Pages
             return UnassignedTaskTableRows[1].FindElements(By.TagName("td")).Count != 0 && int.Parse(UnassignedTaskTableRows[1].FindElements(By.TagName("td"))[0].Text) == processId
                    && AssignedTaskTableRows[1].FindElements(By.TagName("td")).Count != 0 && int.Parse(AssignedTaskTableRows[1].FindElements(By.TagName("td"))[0].Text) == processId;
         }
-
-        public void SelectAssessment()
-        {
-            ClickOnTask.Click();
-        }
     }
 }

--- a/src/Portal.TestAutomation.Framework/Pages/ReviewPage.cs
+++ b/src/Portal.TestAutomation.Framework/Pages/ReviewPage.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using Common.Helpers;
 using Microsoft.Extensions.Configuration;
 using OpenQA.Selenium;
@@ -57,20 +56,5 @@ namespace Portal.TestAutomation.Framework.Pages
             _driver.Navigate().GoToUrl(ReviewPageUrl + "?processId=" + processId);
             _driver.Manage().Window.Maximize();
         }
-
-        public void ExpandSourceDocumentDetails()
-        {
-            ExpandSourceDocument.Click();
-        }
-
-        public int SourceDocumentRowCount()
-        {
-            int rowCount = SourceDocumentTable.FindElements(By.TagName("tr")).Count;
-
-            return rowCount;
-        }
-
-
-
     }
 }

--- a/src/Portal.TestAutomation.Framework/Pages/ReviewPage.cs
+++ b/src/Portal.TestAutomation.Framework/Pages/ReviewPage.cs
@@ -54,6 +54,12 @@ namespace Portal.TestAutomation.Framework.Pages
             _driver.Manage().Window.Maximize();
         }
 
+        public void NavigateToProcessId(int processId)
+        {
+            _driver.Navigate().GoToUrl(ReviewPageUrl + "?processId=" + processId);
+            _driver.Manage().Window.Maximize();
+        }
+
         public void ExpandSourceDocumentDetails()
         {
             ExpandSourceDocument.Click();

--- a/src/Portal.TestAutomation.Framework/Pages/ReviewPage.cs
+++ b/src/Portal.TestAutomation.Framework/Pages/ReviewPage.cs
@@ -19,9 +19,9 @@ namespace Portal.TestAutomation.Framework.Pages
 
         private IWebElement UkhoLogo => _driver.FindElement(By.Id("ukhoLogo"));
 
-        private IWebElement ExpandSourceDocument => _driver.FindElement(By.XPath("//*[@id='sourceDocuments']/div/div/table/tbody/tr[1]"));
+        private IWebElement ExpandSourceDocument => _driver.FindElement(By.XPath("//*[@id='sourceDocuments']//table/tbody/tr[1]"));
 
-        private IWebElement SourceDocumentTable => _driver.FindElement(By.XPath("//*[@id='sourceDocuments']/div/div/table/tbody"));
+        private IWebElement SourceDocumentTable => _driver.FindElement(By.XPath("//*[@id='sourceDocuments']//table/tbody"));
         
         public ReviewPage(IWebDriver driver, int seconds)
         {

--- a/src/Portal.TestAutomation.Framework/Pages/ReviewPage.cs
+++ b/src/Portal.TestAutomation.Framework/Pages/ReviewPage.cs
@@ -19,8 +19,6 @@ namespace Portal.TestAutomation.Framework.Pages
 
         private IWebElement UkhoLogo => _driver.FindElement(By.Id("ukhoLogo"));
 
-        private IWebElement ExpandSourceDocument => _driver.FindElement(By.XPath("//*[@id='sourceDocuments']//table/tbody/tr[1]"));
-
         private IWebElement SourceDocumentTable => _driver.FindElement(By.XPath("//*[@id='sourceDocuments']//table/tbody"));
         
         public ReviewPage(IWebDriver driver, int seconds)

--- a/src/Portal.TestAutomation.Framework/Pages/ReviewPage.cs
+++ b/src/Portal.TestAutomation.Framework/Pages/ReviewPage.cs
@@ -65,5 +65,8 @@ namespace Portal.TestAutomation.Framework.Pages
 
             return rowCount;
         }
+
+
+
     }
 }

--- a/src/Portal.TestAutomation.Framework/Pages/ReviewPage.cs
+++ b/src/Portal.TestAutomation.Framework/Pages/ReviewPage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Common.Helpers;
 using Microsoft.Extensions.Configuration;
 using OpenQA.Selenium;
@@ -18,6 +19,10 @@ namespace Portal.TestAutomation.Framework.Pages
 
         private IWebElement UkhoLogo => _driver.FindElement(By.Id("ukhoLogo"));
 
+        private IWebElement ExpandSourceDocument => _driver.FindElement(By.XPath("//*[@id='sourceDocuments']/div/div/table/tbody/tr[1]"));
+
+        private IWebElement SourceDocumentTable => _driver.FindElement(By.XPath("//*[@id='sourceDocuments']/div/div/table/tbody"));
+        
         public ReviewPage(IWebDriver driver, int seconds)
         {
             var configRoot = AzureAppConfigConfigurationRoot.Instance;
@@ -47,6 +52,18 @@ namespace Portal.TestAutomation.Framework.Pages
         {
             _driver.Navigate().GoToUrl(ReviewPageUrl);
             _driver.Manage().Window.Maximize();
+        }
+
+        public void ExpandSourceDocumentDetails()
+        {
+            ExpandSourceDocument.Click();
+        }
+
+        public int SourceDocumentRowCount()
+        {
+            int rowCount = SourceDocumentTable.FindElements(By.TagName("tr")).Count;
+
+            return rowCount;
         }
     }
 }

--- a/src/Portal.TestAutomation.Specs/ReviewPageTasks.feature
+++ b/src/Portal.TestAutomation.Specs/ReviewPageTasks.feature
@@ -6,11 +6,9 @@ Scenario: The review page loads
 	 Then The review page has loaded
 
 @mytag
-Scenario: The linked documents on the review page are present
+Scenario: The source document on the review page is present
 	 Given The review page has loaded with the first process Id
-	 When I expand the source document details
-	 Then the linked documents are displayed on the screen
-	 Then the linked documents displayed on the screen are the same as in the database
+	  Then The source document with the corresponding process Id in the database matches the sdocId on the UI
 
 
 

--- a/src/Portal.TestAutomation.Specs/ReviewPageTasks.feature
+++ b/src/Portal.TestAutomation.Specs/ReviewPageTasks.feature
@@ -7,13 +7,13 @@ Scenario: The review page loads
 
 @mytag
 Scenario: The linked documents on the review page are present
-Given I navigate to the landing page
-When I click an assessment
-Then The review page has loaded
-Then process ID on the screen has a unique entry in the database
-When I expand the source document details
-Then the linked documents are displayed on the screen
-Then the linked documents displayed on the screen are the same as in the database
+	Given I navigate to the landing page
+	 When I click an assessment
+	 Then The review page has loaded
+	 #Then process ID on the screen has a unique entry in the database
+	 When I expand the source document details
+	 Then the linked documents are displayed on the screen
+	 #Then the linked documents displayed on the screen are the same as in the database
 
 
 

--- a/src/Portal.TestAutomation.Specs/ReviewPageTasks.feature
+++ b/src/Portal.TestAutomation.Specs/ReviewPageTasks.feature
@@ -4,3 +4,19 @@
 Scenario: The review page loads
 	Given I navigate to the review page 
 	 Then The review page has loaded
+
+@mytag
+Scenario: The linked documents on the review page are present
+Given I navigate to the landing page
+When I click an assessment
+Then The review page has loaded
+Then process ID on the screen has a unique entry in the database
+When I expand the source document details
+Then the linked documents are displayed on the screen
+Then the linked documents displayed on the screen are the same as in the database
+
+
+
+
+
+

--- a/src/Portal.TestAutomation.Specs/ReviewPageTasks.feature
+++ b/src/Portal.TestAutomation.Specs/ReviewPageTasks.feature
@@ -10,7 +10,6 @@ Scenario: The linked documents on the review page are present
 	Given I navigate to the landing page
 	 When I click an assessment
 	 Then The review page has loaded
-	 #Then process ID on the screen has a unique entry in the database
 	 When I expand the source document details
 	 Then the linked documents are displayed on the screen
 	 #Then the linked documents displayed on the screen are the same as in the database

--- a/src/Portal.TestAutomation.Specs/ReviewPageTasks.feature
+++ b/src/Portal.TestAutomation.Specs/ReviewPageTasks.feature
@@ -7,9 +7,7 @@ Scenario: The review page loads
 
 @mytag
 Scenario: The linked documents on the review page are present
-	Given I navigate to the landing page
-	 When I click an assessment
-	 Then The review page has loaded
+	 Given The review page has loaded with the first process Id
 	 When I expand the source document details
 	 Then the linked documents are displayed on the screen
 	 Then the linked documents displayed on the screen are the same as in the database

--- a/src/Portal.TestAutomation.Specs/ReviewPageTasks.feature
+++ b/src/Portal.TestAutomation.Specs/ReviewPageTasks.feature
@@ -12,7 +12,7 @@ Scenario: The linked documents on the review page are present
 	 Then The review page has loaded
 	 When I expand the source document details
 	 Then the linked documents are displayed on the screen
-	 #Then the linked documents displayed on the screen are the same as in the database
+	 Then the linked documents displayed on the screen are the same as in the database
 
 
 

--- a/src/Portal.TestAutomation.Steps/LandingPageSteps.cs
+++ b/src/Portal.TestAutomation.Steps/LandingPageSteps.cs
@@ -42,11 +42,5 @@ namespace Portal.TestAutomation.Steps
         {
             Assert.IsTrue(_landingPage.FindTaskByProcessId(p0));
         }
-
-        [When(@"I click an assessment")]
-        public void WhenIClickAnAssessment()
-        {
-            _landingPage.SelectAssessment();
-        }
     }
 }

--- a/src/Portal.TestAutomation.Steps/LandingPageSteps.cs
+++ b/src/Portal.TestAutomation.Steps/LandingPageSteps.cs
@@ -42,5 +42,11 @@ namespace Portal.TestAutomation.Steps
         {
             Assert.IsTrue(_landingPage.FindTaskByProcessId(p0));
         }
+
+        [When(@"I click an assessment")]
+        public void WhenIClickAnAssessment()
+        {
+            _landingPage.SelectAssessment();
+        }
     }
 }

--- a/src/Portal.TestAutomation.Steps/ReviewPageSteps.cs
+++ b/src/Portal.TestAutomation.Steps/ReviewPageSteps.cs
@@ -1,4 +1,6 @@
-﻿using Common.Helpers;
+﻿using System.Runtime.CompilerServices;
+using Common.Helpers;
+using NUnit.Framework;
 using OpenQA.Selenium;
 using Portal.TestAutomation.Framework.Pages;
 using TechTalk.SpecFlow;
@@ -10,7 +12,7 @@ namespace Portal.TestAutomation.Steps
     public class ReviewPageSteps
     {
         private readonly ReviewPage _reviewPage;
-
+        
         public ReviewPageSteps(IWebDriver driver, WorkflowDbContext workflowDbContext)
         {
             //TestWorkflowDatabaseSeeder.UsingDbContext(workflowDbContext).PopulateTables().SaveChanges();
@@ -30,35 +32,24 @@ namespace Portal.TestAutomation.Steps
             _reviewPage.HasLoaded();
         }
 
-        [When(@"I click an assessment")]
-        public void WhenIClickAnAssessment()
+        [When(@"I expand the source document details")]
+        public void WhenIExpandTheSourceDocumentDetails()
         {
-            ScenarioContext.Current.Pending();
+            _reviewPage.ExpandSourceDocumentDetails();
         }
 
-        //[Then(@"process ID on the screen has a unique entry in the database")]
-        //public void ThenProcessIDOnTheScreenHasAUniqueEntryInTheDatabase()
-        //{
-        //    ScenarioContext.Current.Pending();
-        //}
-
-        //[When(@"I expand the source document details")]
-        //public void WhenIExpandTheSourceDocumentDetails()
-        //{
-        //    ScenarioContext.Current.Pending();
-        //}
-
-        //[Then(@"the linked documents are displayed on the screen")]
-        //public void ThenTheLinkedDocumentsAreDisplayedOnTheScreen()
-        //{
-        //    ScenarioContext.Current.Pending();
-        //}
+        [Then(@"the linked documents are displayed on the screen")]
+        public void ThenTheLinkedDocumentsAreDisplayedOnTheScreen()
+        {
+            Assert.IsTrue(_reviewPage.SourceDocumentRowCount() > 1);
+        }
 
         //[Then(@"the linked documents displayed on the screen are the same as in the database")]
         //public void ThenTheLinkedDocumentsDisplayedOnTheScreenAreTheSameAsInTheDatabase()
         //{
         //    ScenarioContext.Current.Pending();
         //}
-
     }
 }
+
+

--- a/src/Portal.TestAutomation.Steps/ReviewPageSteps.cs
+++ b/src/Portal.TestAutomation.Steps/ReviewPageSteps.cs
@@ -11,9 +11,11 @@ namespace Portal.TestAutomation.Steps
     [Binding]
     public class ReviewPageSteps
     {
+        private IWebElement firstUiDisplayDoc => _driver.FindElement(By.XPath("/html/body//table/tbody/tr/td[contains(text(),'217547')]"));
         private readonly ReviewPage _reviewPage;
         private readonly WorkflowDbContext _workflowDbContext;
         private readonly WorkflowInstanceContext _workflowContext;
+        private readonly IWebDriver _driver;
 
         public ReviewPageSteps(IWebDriver driver, WorkflowDbContext workflowDbContext, WorkflowInstanceContext workflowContext)
         {
@@ -62,6 +64,7 @@ namespace Portal.TestAutomation.Steps
           var sourcedocs = _workflowDbContext.SourceDocumentStatus.Where(x => x.ProcessId == _workflowContext.ProcessId).ToList();
 
           var d = sourcedocs.First(x => x.SdocId == sdocId);
+          Assert.AreSame(d, firstUiDisplayDoc);
         }
     }
 }

--- a/src/Portal.TestAutomation.Steps/ReviewPageSteps.cs
+++ b/src/Portal.TestAutomation.Steps/ReviewPageSteps.cs
@@ -5,7 +5,7 @@ using TechTalk.SpecFlow;
 using WorkflowDatabase.EF;
 
 namespace Portal.TestAutomation.Steps
-{ 
+{
     [Binding]
     public class ReviewPageSteps
     {
@@ -29,5 +29,36 @@ namespace Portal.TestAutomation.Steps
         {
             _reviewPage.HasLoaded();
         }
+
+        [When(@"I click an assessment")]
+        public void WhenIClickAnAssessment()
+        {
+            ScenarioContext.Current.Pending();
+        }
+
+        //[Then(@"process ID on the screen has a unique entry in the database")]
+        //public void ThenProcessIDOnTheScreenHasAUniqueEntryInTheDatabase()
+        //{
+        //    ScenarioContext.Current.Pending();
+        //}
+
+        //[When(@"I expand the source document details")]
+        //public void WhenIExpandTheSourceDocumentDetails()
+        //{
+        //    ScenarioContext.Current.Pending();
+        //}
+
+        //[Then(@"the linked documents are displayed on the screen")]
+        //public void ThenTheLinkedDocumentsAreDisplayedOnTheScreen()
+        //{
+        //    ScenarioContext.Current.Pending();
+        //}
+
+        //[Then(@"the linked documents displayed on the screen are the same as in the database")]
+        //public void ThenTheLinkedDocumentsDisplayedOnTheScreenAreTheSameAsInTheDatabase()
+        //{
+        //    ScenarioContext.Current.Pending();
+        //}
+
     }
 }

--- a/src/Portal.TestAutomation.Steps/ReviewPageSteps.cs
+++ b/src/Portal.TestAutomation.Steps/ReviewPageSteps.cs
@@ -11,7 +11,6 @@ namespace Portal.TestAutomation.Steps
     [Binding]
     public class ReviewPageSteps
     {
-        private IWebElement firstUiDisplayDoc => _driver.FindElement(By.XPath("/html/body//table/tbody/tr/td[contains(text(),'217547')]"));
         private readonly ReviewPage _reviewPage;
         private readonly WorkflowDbContext _workflowDbContext;
         private readonly WorkflowInstanceContext _workflowContext;
@@ -45,26 +44,12 @@ namespace Portal.TestAutomation.Steps
             _reviewPage.HasLoaded();
         }
 
-        [When(@"I expand the source document details")]
-        public void WhenIExpandTheSourceDocumentDetails()
+       [Then(@"The source document with the corresponding process Id in the database matches the sdocId on the UI")]
+        public void ThenTheSourceDocumentWithTheCorrespondingProcessIdInTheDatabaseMatchesTheSdocIdOnTheUI()
         {
-            _reviewPage.ExpandSourceDocumentDetails();
-        }
-
-        [Then(@"the linked documents are displayed on the screen")]
-        public void ThenTheLinkedDocumentsAreDisplayedOnTheScreen()
-        {
-            Assert.IsTrue(_reviewPage.SourceDocumentRowCount() > 1);
-        }
-
-        [Then(@"the linked documents displayed on the screen are the same as in the database")]
-        public void ThenTheLinkedDocumentsDisplayedOnTheScreenAreTheSameAsInTheDatabase()
-        {
-          var sdocId = _workflowDbContext.AssessmentData.First(x => x.ProcessId == _workflowContext.ProcessId).SdocId;
-          var sourcedocs = _workflowDbContext.SourceDocumentStatus.Where(x => x.ProcessId == _workflowContext.ProcessId).ToList();
-
-          var d = sourcedocs.First(x => x.SdocId == sdocId);
-          Assert.AreSame(d, firstUiDisplayDoc);
+            var sdocId = _workflowDbContext.AssessmentData.First(x => x.ProcessId == _workflowContext.ProcessId).SdocId;
+            var firstUiDisplayDoc = _driver.FindElement(By.XPath($"/html/body//table/tbody/tr/td[contains(text(),{sdocId})]"));
+            Assert.AreSame(sdocId, firstUiDisplayDoc);
         }
     }
 }

--- a/src/Portal.TestAutomation.Steps/ReviewPageSteps.cs
+++ b/src/Portal.TestAutomation.Steps/ReviewPageSteps.cs
@@ -1,11 +1,10 @@
-﻿using System.Runtime.CompilerServices;
-using Common.Helpers;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using OpenQA.Selenium;
 using Portal.TestAutomation.Framework.Pages;
 using TechTalk.SpecFlow;
 using WorkflowDatabase.EF;
 using System.Linq;
+using Portal.TestAutomation.Framework.ContextClasses;
 
 namespace Portal.TestAutomation.Steps
 {
@@ -13,12 +12,14 @@ namespace Portal.TestAutomation.Steps
     public class ReviewPageSteps
     {
         private readonly ReviewPage _reviewPage;
-        private readonly WorkflowDbContext workflowDbContext;
+        private readonly WorkflowDbContext _workflowDbContext;
+        private readonly WorkflowInstanceContext _workflowContext;
 
-        public ReviewPageSteps(IWebDriver driver, WorkflowDbContext workflowDbContext)
+        public ReviewPageSteps(IWebDriver driver, WorkflowDbContext workflowDbContext, WorkflowInstanceContext workflowContext)
         {
-            //TestWorkflowDatabaseSeeder.UsingDbContext(workflowDbContext).PopulateTables().SaveChanges();
-
+            _workflowDbContext = workflowDbContext;
+            _workflowContext = workflowContext;
+            //TestWorkflowDatabaseSeeder.UsingDbContext(_workflowDbContext).PopulateTables().SaveChanges();
             _reviewPage = new ReviewPage(driver, 5);
         }
 
@@ -26,6 +27,14 @@ namespace Portal.TestAutomation.Steps
         public void GivenINavigateToTheReviewPage()
         {
             _reviewPage.NavigateTo();
+        }
+
+        [Given(@"The review page has loaded with the first process Id")]
+        public void GivenTheReviewPageHasLoadedWithTheFirstProcessId()
+        {
+            var firstProcessId = _workflowDbContext.WorkflowInstance.First().ProcessId;
+            _workflowContext.ProcessId = firstProcessId;
+            _reviewPage.NavigateToProcessId(firstProcessId);
         }
 
         [Then(@"The review page has loaded")]
@@ -49,9 +58,8 @@ namespace Portal.TestAutomation.Steps
         [Then(@"the linked documents displayed on the screen are the same as in the database")]
         public void ThenTheLinkedDocumentsDisplayedOnTheScreenAreTheSameAsInTheDatabase()
         {
-          var firstProcessId =  workflowDbContext.WorkflowInstance.First().ProcessId;
-          var sdocId = workflowDbContext.AssessmentData.First(x => x.ProcessId == firstProcessId).SdocId;
-          var sourcedocs = workflowDbContext.SourceDocumentStatus.Where(x => x.ProcessId == firstProcessId).ToList();
+          var sdocId = _workflowDbContext.AssessmentData.First(x => x.ProcessId == _workflowContext.ProcessId).SdocId;
+          var sourcedocs = _workflowDbContext.SourceDocumentStatus.Where(x => x.ProcessId == _workflowContext.ProcessId).ToList();
 
           var d = sourcedocs.First(x => x.SdocId == sdocId);
         }

--- a/src/Portal.TestAutomation.Steps/ReviewPageSteps.cs
+++ b/src/Portal.TestAutomation.Steps/ReviewPageSteps.cs
@@ -5,6 +5,7 @@ using OpenQA.Selenium;
 using Portal.TestAutomation.Framework.Pages;
 using TechTalk.SpecFlow;
 using WorkflowDatabase.EF;
+using System.Linq;
 
 namespace Portal.TestAutomation.Steps
 {
@@ -12,7 +13,8 @@ namespace Portal.TestAutomation.Steps
     public class ReviewPageSteps
     {
         private readonly ReviewPage _reviewPage;
-        
+        private readonly WorkflowDbContext workflowDbContext;
+
         public ReviewPageSteps(IWebDriver driver, WorkflowDbContext workflowDbContext)
         {
             //TestWorkflowDatabaseSeeder.UsingDbContext(workflowDbContext).PopulateTables().SaveChanges();
@@ -44,11 +46,15 @@ namespace Portal.TestAutomation.Steps
             Assert.IsTrue(_reviewPage.SourceDocumentRowCount() > 1);
         }
 
-        //[Then(@"the linked documents displayed on the screen are the same as in the database")]
-        //public void ThenTheLinkedDocumentsDisplayedOnTheScreenAreTheSameAsInTheDatabase()
-        //{
-        //    ScenarioContext.Current.Pending();
-        //}
+        [Then(@"the linked documents displayed on the screen are the same as in the database")]
+        public void ThenTheLinkedDocumentsDisplayedOnTheScreenAreTheSameAsInTheDatabase()
+        {
+          var firstProcessId =  workflowDbContext.WorkflowInstance.First().ProcessId;
+          var sdocId = workflowDbContext.AssessmentData.First(x => x.ProcessId == firstProcessId).SdocId;
+          var sourcedocs = workflowDbContext.SourceDocumentStatus.Where(x => x.ProcessId == firstProcessId).ToList();
+
+          var d = sourcedocs.First(x => x.SdocId == sdocId);
+        }
     }
 }
 


### PR DESCRIPTION
- Use context class to pass around the ProcessId
- Navigate to the Review page directly using the first row from the WorkflowInstance table
- Ensure the source document's sdocId matches between the db and the UI