### PR TITLE
Fix auto test on Portal for finding by process ID

### DIFF
--- a/src/Portal.TestAutomation.Framework/Pages/LandingPage.cs
+++ b/src/Portal.TestAutomation.Framework/Pages/LandingPage.cs
@@ -80,7 +80,7 @@ namespace Portal.TestAutomation.Framework.Pages
 
             foreach (var row in InFlightTaskTableActualDataRows)
             {
-                int.TryParse(row.FindElements(By.TagName("td"))[0].Text, out var found);
+                int.TryParse(row.FindElements(By.TagName("td"))[1].Text, out var found);
                 if (found == processId) return true;
             }
 


### PR DESCRIPTION
We have added a new column to the inflight tasks table on the landing page, so shift index on FindElements() in step.