### PR TITLE
Migrate build to use stages

### DIFF
--- a/portal-azure-pipelines.yml
+++ b/portal-azure-pipelines.yml
@@ -1,174 +1,168 @@
-# Starter pipeline
-# Start with a minimal pipeline that you can customize to build and deploy your code.
-# Add steps that build, run tests, deploy, and more:
-# https://aka.ms/yaml
-
-jobs:
-- job: RestoreBuildAndDeploy
-  pool: 
-    UKHO Windows 2019
-
-  workspace:
-    clean: all
-
-  steps:
-
-  - task: DotNetCoreCLI@2
-    inputs:
-      command: 'restore'
-      projects: '$(Build.SourcesDirectory)\\src\\portal\\portal\\portal.csproj'
-      feedsToUse: 'select'
-    displayName: 'dotnet restore portal'
-
-  - task: DotNetCoreCLI@2
-    inputs:
-      command: 'build'
-      projects: '$(Build.SourcesDirectory)\\src\\portal\\portal\\portal.csproj'
-    displayName: 'dotnet build portal'
-
-  - task: DotNetCoreCLI@2
-    inputs:
-      command: 'restore'
-      projects: '$(Build.SourcesDirectory)\\src\\portal\\portal.unittests\\portal.unittests.csproj'
-      feedsToUse: 'select'
-    displayName: 'dotnet restore portaltests'
-
-  - task: DotNetCoreCLI@2
-    inputs:
-      command: 'build'
-      projects: '$(Build.SourcesDirectory)\\src\\portal\\portal.unittests\\portal.unittests.csproj'
-    displayName: 'dotnet build portaltests'
-
-  - task: DotNetCoreCLI@2
-    inputs:
-      command: 'test'
-      projects: '$(Build.SourcesDirectory)\\src\\portal\\portal.unittests\\portal.unittests.csproj'
-    displayName: 'dotnet test portaltests'
-
-  - task: DotNetCoreCLI@2
-    inputs:
-      command: 'restore'
-      projects: '$(Build.SourcesDirectory)\\src\\Portal.TestAutomation.Specs\\Portal.TestAutomation.Specs.csproj'
-      feedsToUse: 'select'
-    displayName: 'dotnet restore portalspecs'
-
-  - task: DotNetCoreCLI@2
-    inputs:
-      command: 'build'
-      projects: '$(Build.SourcesDirectory)\\src\\Portal.TestAutomation.Specs\\Portal.TestAutomation.Specs.csproj'
-    displayName: 'dotnet build portalspecs'
-
-  - task: CmdLine@2
-    inputs:
-      script: 'choco install pickles'
-    displayName: Install Pickles
-
-  - task: CmdLine@2
-    inputs:
-      script: 'pickles --feature-directory=$(System.DefaultWorkingDirectory)\\src\\Portal.TestAutomation.Specs --output-directory=$(System.DefaultWorkingDirectory)\\src\\Pickles.GeneratedDocumentation --system-under-test-name="Task Manager - Portal" --documentation-format=dhtml'
-    displayName: Generate Pickles Documentation
-
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: '$(System.DefaultWorkingDirectory)\src\Pickles.GeneratedDocumentation'
-      ArtifactName: 'drop'
-      publishLocation: 'Container'
-    displayName: Publish Pickles Artifact
-
-  - task: AzureFileCopy@3
-    inputs:
-      SourcePath: '$(System.DefaultWorkingDirectory)\src\Pickles.GeneratedDocumentation'
-      azureSubscription: 'TPE General Dev'
-      Destination: 'AzureBlob'
-      storage: 'leadtestsa'
-      ContainerName: '$web/$(Build.Repository.Name)'
-    displayName: Publish Pickles Artifact to Azure Blob Storage 
-
-  - task: DotNetCoreCLI@2
-    inputs:
-      command: 'publish'
-      publishWebProjects: false
-      projects: '$(Build.SourcesDirectory)\\src\\portal\\portal\\portal.csproj'
-      zipAfterPublish: false
-      arguments: '--output $(Build.ArtifactStagingDirectory)\\portal'
-    displayName: 'Publish portal-project'
-
-  - task: DotNetCoreCLI@2
-    inputs:
-      command: 'publish'
-      publishWebProjects: false
-      projects: '$(Build.SourcesDirectory)\\src\\Portal.TestAutomation.Specs\\Portal.TestAutomation.Specs.csproj'
-      zipAfterPublish: false
-      arguments: '--output $(Build.ArtifactStagingDirectory)\\Specs'
-    displayName: 'Publish specs-project'
-
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)\\portal'
-      ArtifactName: 'portal'
-      publishLocation: 'Container'
-    displayName: 'Publish portal Artifact'
-
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)\\specs'
-      ArtifactName: 'specs'
-      publishLocation: 'Container'
-    displayName: 'Publish specs Artifact'
-
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download Build Artifacts'
-    inputs:
-      buildType: 'current'
-      downloadType: 'specific'
-      downloadPath: '$(System.ArtifactsDirectory)' 
-
-- deployment: DeployPortalWebsite
-  displayName: deploy Web App
-  pool:
-    vmImage: 'Ubuntu-16.04'
-  # creates an environment if it doesn't exist
-  environment: 'tm2dev'
-  strategy:
-    # default deployment strategy, more coming...
-    runOnce:
-      deploy:
+stages:
+- stage: Build
+  jobs:
+    - job: RestoreBuildAndDeploy
+        pool:
+          UKHO Windows 2019
+        workspace:
+          clean: all
         steps:
-        - task: AzureRmWebAppDeployment@4
-          displayName: 'Azure App Service Deploy'
+        - task: DotNetCoreCLI@2
           inputs:
+            command: 'restore'
+            projects: '$(Build.SourcesDirectory)\\src\\portal\\portal\\portal.csproj'
+            feedsToUse: 'select'
+          displayName: 'dotnet restore portal'
+    
+        - task: DotNetCoreCLI@2
+          inputs:
+            command: 'build'
+            projects: '$(Build.SourcesDirectory)\\src\\portal\\portal\\portal.csproj'
+          displayName: 'dotnet build portal'
+    
+        - task: DotNetCoreCLI@2
+          inputs:
+            command: 'restore'
+            projects: '$(Build.SourcesDirectory)\\src\\portal\\portal.unittests\\portal.unittests    .csproj'
+            feedsToUse: 'select'
+          displayName: 'dotnet restore portaltests'
+    
+        - task: DotNetCoreCLI@2
+          inputs:
+            command: 'build'
+            projects: '$(Build.SourcesDirectory)\\src\\portal\\portal.unittests\\portal.unittests    .csproj'
+          displayName: 'dotnet build portaltests'
+    
+        - task: DotNetCoreCLI@2
+          inputs:
+            command: 'test'
+            projects: '$(Build.SourcesDirectory)\\src\\portal\\portal.unittests\\portal.unittests    .csproj'
+          displayName: 'dotnet test portaltests'
+    
+        - task: DotNetCoreCLI@2
+          inputs:
+            command: 'restore'
+            projects: '$(Build.SourcesDirectory)\\src\\Portal.TestAutomation.Specs\\Portal    .TestAutomation.Specs.csproj'
+            feedsToUse: 'select'
+          displayName: 'dotnet restore portalspecs'
+    
+        - task: DotNetCoreCLI@2
+          inputs:
+            command: 'build'
+            projects: '$(Build.SourcesDirectory)\\src\\Portal.TestAutomation.Specs\\Portal    .TestAutomation.Specs.csproj'
+          displayName: 'dotnet build portalspecs'
+    
+        - task: CmdLine@2
+          inputs:
+            script: 'choco install pickles'
+          displayName: Install Pickles
+    
+        - task: CmdLine@2
+          inputs:
+            script: 'pickles --feature-directory=$(System.DefaultWorkingDirectory)\\src\\Portal    .TestAutomation.Specs --output-directory=$(System.DefaultWorkingDirectory    )\\src\\Pickles.GeneratedDocumentation --system-under-test-name="Task Manager -     Portal" --documentation-format=dhtml'
+          displayName: Generate Pickles Documentation
+    
+        - task: PublishBuildArtifacts@1
+          inputs:
+            PathtoPublish: '$(System.DefaultWorkingDirectory)\src\Pickles.GeneratedDocumentation'
+            ArtifactName: 'drop'
+            publishLocation: 'Container'
+          displayName: Publish Pickles Artifact
+    
+        - task: AzureFileCopy@3
+          inputs:
+            SourcePath: '$(System.DefaultWorkingDirectory)\src\Pickles.GeneratedDocumentation'
+            azureSubscription: 'TPE General Dev'
+            Destination: 'AzureBlob'
+            storage: 'leadtestsa'
+            ContainerName: '$web/$(Build.Repository.Name)'
+          displayName: Publish Pickles Artifact to Azure Blob Storage 
+    
+        - task: DotNetCoreCLI@2
+          inputs:
+            command: 'publish'
+            publishWebProjects: false
+            projects: '$(Build.SourcesDirectory)\\src\\portal\\portal\\portal.csproj'
+            zipAfterPublish: false
+            arguments: '--output $(Build.ArtifactStagingDirectory)\\portal'
+          displayName: 'Publish portal-project'
+    
+        - task: DotNetCoreCLI@2
+          inputs:
+            command: 'publish'
+            publishWebProjects: false
+            projects: '$(Build.SourcesDirectory)\\src\\Portal.TestAutomation.Specs\\Portal    .TestAutomation.Specs.csproj'
+            zipAfterPublish: false
+            arguments: '--output $(Build.ArtifactStagingDirectory)\\Specs'
+          displayName: 'Publish specs-project'
+    
+        - task: PublishBuildArtifacts@1
+          inputs:
+            PathtoPublish: '$(Build.ArtifactStagingDirectory)\\portal'
+            ArtifactName: 'portal'
+            publishLocation: 'Container'
+          displayName: 'Publish portal Artifact'
+    
+        - task: PublishBuildArtifacts@1
+          inputs:
+            PathtoPublish: '$(Build.ArtifactStagingDirectory)\\specs'
+            ArtifactName: 'specs'
+            publishLocation: 'Container'
+          displayName: 'Publish specs Artifact'
+
+- stage: Deploy Dev
+  jobs:    
+    - deployment: DeployPortalWebsite
+        displayName: deploy Web App
+        pool:
+          vmImage: 'Ubuntu-16.04'
+        # creates an environment if it doesn't exist
+        environment: 'tm2dev'
+        strategy:
+        # default deployment strategy, more coming...
+          runOnce:
+            deploy:
+              steps:
+                - task: DownloadBuildArtifacts@0
+                  displayName: 'Download Build Artifacts'
+                  inputs:
+                    buildType: 'current'
+                    downloadType: 'specific'
+                    downloadPath: '$(System.ArtifactsDirectory)' 
+                - task: AzureRmWebAppDeployment@4
+                  displayName: 'Azure App Service Deploy'
+                  inputs:
+                    azureSubscription: 'TM2-Dev'
+                    WebAppName: 'taskmanager-dev-web-portal'
+                    packageForLinux: '$(System.ArtifactsDirectory)/Portal/portal'
+
+    - job: RunAutomatedTests
+        dependsOn: DeployPortalWebsite
+        pool:
+          NautilusBuild
+        steps:
+          - task: PowerShell@2
+            inputs:
+            targetType: 'inline'
+            script: |
+              Install-Module -Name "UKHO.ChromeDriver.BinarySync"  -Repository "ukho.psgallery"
+              Update-ChromeDriver -ChromeDriverDownloads \\mgmt.local\dfs\DML-SW-Engineering\Chrome\ChromeDriver -IncludeBeta
+
+          - task: DownloadBuildArtifacts@0
+            displayName: 'Download Build Artifacts'
+            inputs:
+              buildType: 'current'
+              downloadType: 'specific'
+              downloadPath: '$(System.ArtifactsDirectory)' 
+
+          - task: AzureCLI@1
+            inputs:
             azureSubscription: 'TM2-Dev'
-            WebAppName: 'taskmanager-dev-web-portal'
-            packageForLinux: '$(System.ArtifactsDirectory)/Portal/portal'
+            scriptLocation: 'inlineScript'
+              inlineScript: 'call dotnet vstest $(System.ArtifactsDirectory)\specs\Portal.TestAutomation.Specs\Portal.TestAutomation.Specs.dll --logger:trx'
+              displayName: 'Run SpecFlow tests'
 
-- job: RunAutomatedTests
-  dependsOn: RestoreBuildAndDeploy
-  pool:
-   NautilusBuild
-
-  steps:
-  - task: PowerShell@2
-    inputs:
-      targetType: 'inline'
-      script: |
-        Install-Module -Name "UKHO.ChromeDriver.BinarySync"  -Repository "ukho.psgallery"
-        Update-ChromeDriver -ChromeDriverDownloads \\mgmt.local\dfs\DML-SW-Engineering\Chrome\ChromeDriver -IncludeBeta
-
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download Build Artifacts'
-    inputs:
-      buildType: 'current'
-      downloadType: 'specific'
-      downloadPath: '$(System.ArtifactsDirectory)' 
-
-  - task: AzureCLI@1
-    inputs:
-      azureSubscription: 'TM2-Dev'
-      scriptLocation: 'inlineScript'
-      inlineScript: 'call dotnet vstest $(System.ArtifactsDirectory)\specs\Portal.TestAutomation.Specs\Portal.TestAutomation.Specs.dll --logger:trx'
-    displayName: 'Run SpecFlow tests'
-
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFiles: '**/*.trx'
-      testResultsFormat: 'VSTest'
+          - task: PublishTestResults@2
+            inputs:
+              testResultsFiles: '**/*.trx'
+              testResultsFormat: 'VSTest

--- a/portal-azure-pipelines.yml
+++ b/portal-azure-pipelines.yml
@@ -24,33 +24,33 @@ stages:
       - task: DotNetCoreCLI@2
         inputs:
           command: 'restore'
-          projects: '$(Build.SourcesDirectory)\\src\\portal\\portal.unittests\\portal.unittests    .csproj'
+          projects: '$(Build.SourcesDirectory)\\src\\portal\\portal.unittests\\portal.unittests.csproj'
           feedsToUse: 'select'
         displayName: 'dotnet restore portaltests'
   
       - task: DotNetCoreCLI@2
         inputs:
           command: 'build'
-          projects: '$(Build.SourcesDirectory)\\src\\portal\\portal.unittests\\portal.unittests    .csproj'
+          projects: '$(Build.SourcesDirectory)\\src\\portal\\portal.unittests\\portal.unittests.csproj'
         displayName: 'dotnet build portaltests'
   
       - task: DotNetCoreCLI@2
         inputs:
           command: 'test'
-          projects: '$(Build.SourcesDirectory)\\src\\portal\\portal.unittests\\portal.unittests    .csproj'
+          projects: '$(Build.SourcesDirectory)\\src\\portal\\portal.unittests\\portal.unittests.csproj'
         displayName: 'dotnet test portaltests'
   
       - task: DotNetCoreCLI@2
         inputs:
           command: 'restore'
-          projects: '$(Build.SourcesDirectory)\\src\\Portal.TestAutomation.Specs\\Portal    .TestAutomation.Specs.csproj'
+          projects: '$(Build.SourcesDirectory)\\src\\Portal.TestAutomation.Specs\\Portal.TestAutomation.Specs.csproj'
           feedsToUse: 'select'
         displayName: 'dotnet restore portalspecs'
   
       - task: DotNetCoreCLI@2
         inputs:
           command: 'build'
-          projects: '$(Build.SourcesDirectory)\\src\\Portal.TestAutomation.Specs\\Portal    .TestAutomation.Specs.csproj'
+          projects: '$(Build.SourcesDirectory)\\src\\Portal.TestAutomation.Specs\\Portal.TestAutomation.Specs.csproj'
         displayName: 'dotnet build portalspecs'
   
       - task: CmdLine@2
@@ -60,7 +60,7 @@ stages:
   
       - task: CmdLine@2
         inputs:
-          script: 'pickles --feature-directory=$(System.DefaultWorkingDirectory)\\src\\Portal    .TestAutomation.Specs --output-directory=$(System.DefaultWorkingDirectory    )\\src\\Pickles.GeneratedDocumentation --system-under-test-name="Task Manager -     Portal" --documentation-format=dhtml'
+          script: 'pickles --feature-directory=$(System.DefaultWorkingDirectory)\\src\\Portal.TestAutomation.Specs --output-directory=$(System.DefaultWorkingDirectory)\\src\\Pickles.GeneratedDocumentation --system-under-test-name="Task Manager - Portal" --documentation-format=dhtml'
         displayName: Generate Pickles Documentation
   
       - task: PublishBuildArtifacts@1
@@ -92,7 +92,7 @@ stages:
         inputs:
           command: 'publish'
           publishWebProjects: false
-          projects: '$(Build.SourcesDirectory)\\src\\Portal.TestAutomation.Specs\\Portal    .TestAutomation.Specs.csproj'
+          projects: '$(Build.SourcesDirectory)\\src\\Portal.TestAutomation.Specs\\Portal.TestAutomation.Specs.csproj'
           zipAfterPublish: false
           arguments: '--output $(Build.ArtifactStagingDirectory)\\Specs'
         displayName: 'Publish specs-project'

--- a/portal-azure-pipelines.yml
+++ b/portal-azure-pipelines.yml
@@ -2,167 +2,168 @@ stages:
 - stage: Build
   jobs:
     - job: RestoreBuildAndDeploy
-        pool:
-          UKHO Windows 2019
-        workspace:
+      pool: 
+        UKHO Windows 2019
+      workspace:
           clean: all
-        steps:
-        - task: DotNetCoreCLI@2
-          inputs:
-            command: 'restore'
-            projects: '$(Build.SourcesDirectory)\\src\\portal\\portal\\portal.csproj'
-            feedsToUse: 'select'
-          displayName: 'dotnet restore portal'
+          
+      steps:
+      - task: DotNetCoreCLI@2
+        inputs:
+          command: 'restore'
+          projects: '$(Build.SourcesDirectory)\\src\\portal\\portal\\portal.csproj'
+          feedsToUse: 'select'
+        displayName: 'dotnet restore portal'
     
-        - task: DotNetCoreCLI@2
-          inputs:
-            command: 'build'
-            projects: '$(Build.SourcesDirectory)\\src\\portal\\portal\\portal.csproj'
-          displayName: 'dotnet build portal'
-    
-        - task: DotNetCoreCLI@2
-          inputs:
-            command: 'restore'
-            projects: '$(Build.SourcesDirectory)\\src\\portal\\portal.unittests\\portal.unittests    .csproj'
-            feedsToUse: 'select'
-          displayName: 'dotnet restore portaltests'
-    
-        - task: DotNetCoreCLI@2
-          inputs:
-            command: 'build'
-            projects: '$(Build.SourcesDirectory)\\src\\portal\\portal.unittests\\portal.unittests    .csproj'
-          displayName: 'dotnet build portaltests'
-    
-        - task: DotNetCoreCLI@2
-          inputs:
-            command: 'test'
-            projects: '$(Build.SourcesDirectory)\\src\\portal\\portal.unittests\\portal.unittests    .csproj'
-          displayName: 'dotnet test portaltests'
-    
-        - task: DotNetCoreCLI@2
-          inputs:
-            command: 'restore'
-            projects: '$(Build.SourcesDirectory)\\src\\Portal.TestAutomation.Specs\\Portal    .TestAutomation.Specs.csproj'
-            feedsToUse: 'select'
-          displayName: 'dotnet restore portalspecs'
-    
-        - task: DotNetCoreCLI@2
-          inputs:
-            command: 'build'
-            projects: '$(Build.SourcesDirectory)\\src\\Portal.TestAutomation.Specs\\Portal    .TestAutomation.Specs.csproj'
-          displayName: 'dotnet build portalspecs'
-    
-        - task: CmdLine@2
-          inputs:
-            script: 'choco install pickles'
-          displayName: Install Pickles
-    
-        - task: CmdLine@2
-          inputs:
-            script: 'pickles --feature-directory=$(System.DefaultWorkingDirectory)\\src\\Portal    .TestAutomation.Specs --output-directory=$(System.DefaultWorkingDirectory    )\\src\\Pickles.GeneratedDocumentation --system-under-test-name="Task Manager -     Portal" --documentation-format=dhtml'
-          displayName: Generate Pickles Documentation
-    
-        - task: PublishBuildArtifacts@1
-          inputs:
-            PathtoPublish: '$(System.DefaultWorkingDirectory)\src\Pickles.GeneratedDocumentation'
-            ArtifactName: 'drop'
-            publishLocation: 'Container'
-          displayName: Publish Pickles Artifact
-    
-        - task: AzureFileCopy@3
-          inputs:
-            SourcePath: '$(System.DefaultWorkingDirectory)\src\Pickles.GeneratedDocumentation'
-            azureSubscription: 'TPE General Dev'
-            Destination: 'AzureBlob'
-            storage: 'leadtestsa'
-            ContainerName: '$web/$(Build.Repository.Name)'
-          displayName: Publish Pickles Artifact to Azure Blob Storage 
-    
-        - task: DotNetCoreCLI@2
-          inputs:
-            command: 'publish'
-            publishWebProjects: false
-            projects: '$(Build.SourcesDirectory)\\src\\portal\\portal\\portal.csproj'
-            zipAfterPublish: false
-            arguments: '--output $(Build.ArtifactStagingDirectory)\\portal'
-          displayName: 'Publish portal-project'
-    
-        - task: DotNetCoreCLI@2
-          inputs:
-            command: 'publish'
-            publishWebProjects: false
-            projects: '$(Build.SourcesDirectory)\\src\\Portal.TestAutomation.Specs\\Portal    .TestAutomation.Specs.csproj'
-            zipAfterPublish: false
-            arguments: '--output $(Build.ArtifactStagingDirectory)\\Specs'
-          displayName: 'Publish specs-project'
-    
-        - task: PublishBuildArtifacts@1
-          inputs:
-            PathtoPublish: '$(Build.ArtifactStagingDirectory)\\portal'
-            ArtifactName: 'portal'
-            publishLocation: 'Container'
-          displayName: 'Publish portal Artifact'
-    
-        - task: PublishBuildArtifacts@1
-          inputs:
-            PathtoPublish: '$(Build.ArtifactStagingDirectory)\\specs'
-            ArtifactName: 'specs'
-            publishLocation: 'Container'
-          displayName: 'Publish specs Artifact'
+      - task: DotNetCoreCLI@2
+        inputs:
+          command: 'build'
+          projects: '$(Build.SourcesDirectory)\\src\\portal\\portal\\portal.csproj'
+        displayName: 'dotnet build portal'
+  
+      - task: DotNetCoreCLI@2
+        inputs:
+          command: 'restore'
+          projects: '$(Build.SourcesDirectory)\\src\\portal\\portal.unittests\\portal.unittests    .csproj'
+          feedsToUse: 'select'
+        displayName: 'dotnet restore portaltests'
+  
+      - task: DotNetCoreCLI@2
+        inputs:
+          command: 'build'
+          projects: '$(Build.SourcesDirectory)\\src\\portal\\portal.unittests\\portal.unittests    .csproj'
+        displayName: 'dotnet build portaltests'
+  
+      - task: DotNetCoreCLI@2
+        inputs:
+          command: 'test'
+          projects: '$(Build.SourcesDirectory)\\src\\portal\\portal.unittests\\portal.unittests    .csproj'
+        displayName: 'dotnet test portaltests'
+  
+      - task: DotNetCoreCLI@2
+        inputs:
+          command: 'restore'
+          projects: '$(Build.SourcesDirectory)\\src\\Portal.TestAutomation.Specs\\Portal    .TestAutomation.Specs.csproj'
+          feedsToUse: 'select'
+        displayName: 'dotnet restore portalspecs'
+  
+      - task: DotNetCoreCLI@2
+        inputs:
+          command: 'build'
+          projects: '$(Build.SourcesDirectory)\\src\\Portal.TestAutomation.Specs\\Portal    .TestAutomation.Specs.csproj'
+        displayName: 'dotnet build portalspecs'
+  
+      - task: CmdLine@2
+        inputs:
+          script: 'choco install pickles'
+        displayName: Install Pickles
+  
+      - task: CmdLine@2
+        inputs:
+          script: 'pickles --feature-directory=$(System.DefaultWorkingDirectory)\\src\\Portal    .TestAutomation.Specs --output-directory=$(System.DefaultWorkingDirectory    )\\src\\Pickles.GeneratedDocumentation --system-under-test-name="Task Manager -     Portal" --documentation-format=dhtml'
+        displayName: Generate Pickles Documentation
+  
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: '$(System.DefaultWorkingDirectory)\src\Pickles.GeneratedDocumentation'
+          ArtifactName: 'drop'
+          publishLocation: 'Container'
+        displayName: Publish Pickles Artifact
+  
+      - task: AzureFileCopy@3
+        inputs:
+          SourcePath: '$(System.DefaultWorkingDirectory)\src\Pickles.GeneratedDocumentation'
+          azureSubscription: 'TPE General Dev'
+          Destination: 'AzureBlob'
+          storage: 'leadtestsa'
+          ContainerName: '$web/$(Build.Repository.Name)'
+        displayName: Publish Pickles Artifact to Azure Blob Storage 
+  
+      - task: DotNetCoreCLI@2
+        inputs:
+          command: 'publish'
+          publishWebProjects: false
+          projects: '$(Build.SourcesDirectory)\\src\\portal\\portal\\portal.csproj'
+          zipAfterPublish: false
+          arguments: '--output $(Build.ArtifactStagingDirectory)\\portal'
+        displayName: 'Publish portal-project'
+  
+      - task: DotNetCoreCLI@2
+        inputs:
+          command: 'publish'
+          publishWebProjects: false
+          projects: '$(Build.SourcesDirectory)\\src\\Portal.TestAutomation.Specs\\Portal    .TestAutomation.Specs.csproj'
+          zipAfterPublish: false
+          arguments: '--output $(Build.ArtifactStagingDirectory)\\Specs'
+        displayName: 'Publish specs-project'
+  
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)\\portal'
+          ArtifactName: 'portal'
+          publishLocation: 'Container'
+        displayName: 'Publish portal Artifact'
+  
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)\\specs'
+          ArtifactName: 'specs'
+          publishLocation: 'Container'
+        displayName: 'Publish specs Artifact'
 
 - stage: Deploy Dev
   jobs:    
     - deployment: DeployPortalWebsite
-        displayName: deploy Web App
-        pool:
-          vmImage: 'Ubuntu-16.04'
+      displayName: deploy Web App
+      pool:
+        vmImage: 'Ubuntu-16.04'
         # creates an environment if it doesn't exist
-        environment: 'tm2dev'
-        strategy:
+      environment: 'tm2dev'
+      strategy:
         # default deployment strategy, more coming...
-          runOnce:
-            deploy:
-              steps:
-                - task: DownloadBuildArtifacts@0
-                  displayName: 'Download Build Artifacts'
-                  inputs:
-                    buildType: 'current'
-                    downloadType: 'specific'
-                    downloadPath: '$(System.ArtifactsDirectory)' 
-                - task: AzureRmWebAppDeployment@4
-                  displayName: 'Azure App Service Deploy'
-                  inputs:
-                    azureSubscription: 'TM2-Dev'
-                    WebAppName: 'taskmanager-dev-web-portal'
-                    packageForLinux: '$(System.ArtifactsDirectory)/Portal/portal'
+        runOnce:
+          deploy:
+            steps:
+              - task: DownloadBuildArtifacts@0
+                displayName: 'Download Build Artifacts'
+                inputs:
+                  buildType: 'current'
+                  downloadType: 'specific'
+                  downloadPath: '$(System.ArtifactsDirectory)' 
+              - task: AzureRmWebAppDeployment@4
+                displayName: 'Azure App Service Deploy'
+                inputs:
+                  azureSubscription: 'TM2-Dev'
+                  WebAppName: 'taskmanager-dev-web-portal'
+                  packageForLinux: '$(System.ArtifactsDirectory)/Portal/portal'
 
     - job: RunAutomatedTests
-        dependsOn: DeployPortalWebsite
-        pool:
+      dependsOn: DeployPortalWebsite
+      pool:
           NautilusBuild
-        steps:
-          - task: PowerShell@2
-            inputs:
+      steps:
+        - task: PowerShell@2
+          inputs:
             targetType: 'inline'
             script: |
               Install-Module -Name "UKHO.ChromeDriver.BinarySync"  -Repository "ukho.psgallery"
               Update-ChromeDriver -ChromeDriverDownloads \\mgmt.local\dfs\DML-SW-Engineering\Chrome\ChromeDriver -IncludeBeta
 
-          - task: DownloadBuildArtifacts@0
-            displayName: 'Download Build Artifacts'
-            inputs:
-              buildType: 'current'
-              downloadType: 'specific'
-              downloadPath: '$(System.ArtifactsDirectory)' 
+        - task: DownloadBuildArtifacts@0
+          displayName: 'Download Build Artifacts'
+          inputs:
+            buildType: 'current'
+            downloadType: 'specific'
+            downloadPath: '$(System.ArtifactsDirectory)' 
 
-          - task: AzureCLI@1
-            inputs:
+        - task: AzureCLI@1
+          inputs:
             azureSubscription: 'TM2-Dev'
             scriptLocation: 'inlineScript'
-              inlineScript: 'call dotnet vstest $(System.ArtifactsDirectory)\specs\Portal.TestAutomation.Specs\Portal.TestAutomation.Specs.dll --logger:trx'
-              displayName: 'Run SpecFlow tests'
+            inlineScript: 'call dotnet vstest $(System.ArtifactsDirectory)\specs\Portal.TestAutomation.Specs\Portal.TestAutomation.Specs.dll --logger:trx'
+          displayName: 'Run SpecFlow tests'
 
-          - task: PublishTestResults@2
-            inputs:
-              testResultsFiles: '**/*.trx'
-              testResultsFormat: 'VSTest
+        - task: PublishTestResults@2
+          inputs:
+            testResultsFiles: '**/*.trx'
+            testResultsFormat: 'VSTest'

--- a/portal-azure-pipelines.yml
+++ b/portal-azure-pipelines.yml
@@ -6,7 +6,7 @@ stages:
         UKHO Windows 2019
       workspace:
           clean: all
-          
+
       steps:
       - task: DotNetCoreCLI@2
         inputs:
@@ -111,7 +111,7 @@ stages:
           publishLocation: 'Container'
         displayName: 'Publish specs Artifact'
 
-- stage: Deploy Dev
+- stage: DeployDev
   jobs:    
     - deployment: DeployPortalWebsite
       displayName: deploy Web App


### PR DESCRIPTION
Approvals for an environment deployment block all jobs in that stage from running. At the moment the pipeline has jobs which build the code but are blocked from running as the stage contains a deployment job to an environment with an approval policy.

This PR separates the build and deploy into different stages so it can build and run unit tests but is blocked from deploying to an environment.