### PR TITLE
Clean up workflow DbContext

### DIFF
--- a/src/Databases/WorkflowDatabase.EF/Models/AssignedTaskSourceType.cs
+++ b/src/Databases/WorkflowDatabase.EF/Models/AssignedTaskSourceType.cs
@@ -1,9 +1,7 @@
 ﻿using System.ComponentModel;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace WorkflowDatabase.EF.Models
 {
-    [Table("AssignedTaskSourceType")]
     public class AssignedTaskSourceType
     {
         public int AssignedTaskSourceTypeId { get; set; }

--- a/src/Databases/WorkflowDatabase.EF/Models/CachedHpdWorkspace.cs
+++ b/src/Databases/WorkflowDatabase.EF/Models/CachedHpdWorkspace.cs
@@ -1,9 +1,7 @@
 ﻿using System.ComponentModel;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace WorkflowDatabase.EF.Models
 {
-    [Table("CachedHpdWorkspace")]
     public class CachedHpdWorkspace
     {
         public int CachedHpdWorkspaceId { get; set; }

--- a/src/Databases/WorkflowDatabase.EF/Models/Comment.cs
+++ b/src/Databases/WorkflowDatabase.EF/Models/Comment.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace WorkflowDatabase.EF.Models
 {
-    [Table("Comment")]
-    public class Comments
+    public class Comment
     {
         public int CommentId { get; set; }
         public int ProcessId { get; set; }

--- a/src/Databases/WorkflowDatabase.EF/Models/DbAssessmentAssessData.cs
+++ b/src/Databases/WorkflowDatabase.EF/Models/DbAssessmentAssessData.cs
@@ -1,8 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
-
-namespace WorkflowDatabase.EF.Models
+﻿namespace WorkflowDatabase.EF.Models
 {
-    [Table("DbAssessmentAssessData")]
     public class DbAssessmentAssessData
     {
         public int DbAssessmentAssessDataId { get; set; }

--- a/src/Databases/WorkflowDatabase.EF/Models/DbAssessmentAssignTask.cs
+++ b/src/Databases/WorkflowDatabase.EF/Models/DbAssessmentAssignTask.cs
@@ -1,9 +1,7 @@
 ﻿using System.ComponentModel;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace WorkflowDatabase.EF.Models
 {
-    [Table("DbAssessmentAssignTask")]
     public class DbAssessmentAssignTask
     {
         public int DbAssessmentAssignTaskId { get; set; }

--- a/src/Databases/WorkflowDatabase.EF/Models/DbAssessmentReviewData.cs
+++ b/src/Databases/WorkflowDatabase.EF/Models/DbAssessmentReviewData.cs
@@ -1,9 +1,7 @@
 ﻿using System.ComponentModel;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace WorkflowDatabase.EF.Models
 {
-    [Table("DbAssessmentReviewData")]
     public class DbAssessmentReviewData
     {
         public int DbAssessmentReviewDataId { get; set; }

--- a/src/Databases/WorkflowDatabase.EF/Models/HpdUsage.cs
+++ b/src/Databases/WorkflowDatabase.EF/Models/HpdUsage.cs
@@ -1,8 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
-
-namespace WorkflowDatabase.EF.Models
+﻿namespace WorkflowDatabase.EF.Models
 {
-    [Table("HpdUsage")]
     public class HpdUsage
     {
         public int HpdUsageId { get; set; }

--- a/src/Databases/WorkflowDatabase.EF/Models/HpdUser.cs
+++ b/src/Databases/WorkflowDatabase.EF/Models/HpdUser.cs
@@ -1,8 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
-
-namespace WorkflowDatabase.EF.Models
+﻿namespace WorkflowDatabase.EF.Models
 {
-    [Table("HpdUser")]
     public class HpdUser
     {
         public int HpdUserId { get; set; }

--- a/src/Databases/WorkflowDatabase.EF/Models/LinkedDocument.cs
+++ b/src/Databases/WorkflowDatabase.EF/Models/LinkedDocument.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace WorkflowDatabase.EF.Models
 {
-
-    [Table("LinkedDocument")]
-    public class LinkedDocuments
+    public class LinkedDocument
     {
         public int LinkedDocumentId { get; set; }
         public int ProcessId { get; set; }

--- a/src/Databases/WorkflowDatabase.EF/Models/OnHold.cs
+++ b/src/Databases/WorkflowDatabase.EF/Models/OnHold.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace WorkflowDatabase.EF.Models
 {
-    [Table("OnHold")]
     public class OnHold
     {
         public int OnHoldId { get; set; }
@@ -11,7 +9,7 @@ namespace WorkflowDatabase.EF.Models
         public int ProcessId { get; set; }
         public DateTime OnHoldTime { get; set; }
         public DateTime? OffHoldTime { get; set; }
-        public string OnHoldUser{ get; set; }
+        public string OnHoldUser { get; set; }
         public string OffHoldUser { get; set; }
     }
 }

--- a/src/Databases/WorkflowDatabase.EF/Models/ProductAction.cs
+++ b/src/Databases/WorkflowDatabase.EF/Models/ProductAction.cs
@@ -1,10 +1,7 @@
 ﻿using System.ComponentModel;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace WorkflowDatabase.EF.Models
 {
-    [Table("ProductAction")]
-
     public class ProductAction
     {
         public int ProductActionId { get; set; }
@@ -19,8 +16,7 @@ namespace WorkflowDatabase.EF.Models
 
         [DisplayName("Verified:")]
         public bool Verified { get; set; }
-        
-        public virtual ProductActionType ProductActionType { get; set; }
 
+        public virtual ProductActionType ProductActionType { get; set; }
     }
 }

--- a/src/Databases/WorkflowDatabase.EF/Models/ProductActionType.cs
+++ b/src/Databases/WorkflowDatabase.EF/Models/ProductActionType.cs
@@ -1,9 +1,7 @@
 ﻿using System.ComponentModel;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace WorkflowDatabase.EF.Models
 {
-    [Table("ProductActionType")]
     public class ProductActionType
     {
         public int ProductActionTypeId { get; set; }

--- a/src/Databases/WorkflowDatabase.EF/Models/TaskNote.cs
+++ b/src/Databases/WorkflowDatabase.EF/Models/TaskNote.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace WorkflowDatabase.EF.Models
 {
-    [Table("TaskNote")]
     public class TaskNote
     {
         public int TaskNoteId { get; set; }

--- a/src/Databases/WorkflowDatabase.EF/Models/WorkflowInstance.cs
+++ b/src/Databases/WorkflowDatabase.EF/Models/WorkflowInstance.cs
@@ -14,13 +14,13 @@ namespace WorkflowDatabase.EF.Models
         public DateTime StartedAt { get; set; }
         public string Status { get; set; }
 
-        public virtual List<Comments> Comment { get; set; }
+        public virtual List<Comment> Comments { get; set; }
         public virtual AssessmentData AssessmentData { get; set; }
         public virtual DbAssessmentReviewData DbAssessmentReviewData { get; set; }
         public virtual DbAssessmentAssessData DbAssessmentAssessData { get; set; }
         public virtual PrimaryDocumentStatus PrimaryDocumentStatus { get; set; }
         public virtual List<DatabaseDocumentStatus> DatabaseDocumentStatus { get; set; }
-        public virtual List<LinkedDocuments> LinkedDocument { get; set; }
+        public virtual List<LinkedDocument> LinkedDocument { get; set; }
         public virtual List<OnHold> OnHold { get; set; }
         public virtual TaskNote TaskNote { get; set; }
         public virtual List<DataImpact> DataImpact { get; set; }

--- a/src/Databases/WorkflowDatabase.EF/WorkflowDbContext.cs
+++ b/src/Databases/WorkflowDatabase.EF/WorkflowDbContext.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Data.SqlClient;
-using System.Net.Http.Headers;
 using Microsoft.Azure.Services.AppAuthentication;
 using Microsoft.EntityFrameworkCore;
 using WorkflowDatabase.EF.Models;
@@ -23,13 +22,13 @@ namespace WorkflowDatabase.EF
         }
 
         public DbSet<AssessmentData> AssessmentData { get; set; }
-        public DbSet<Comments> Comment { get; set; }
+        public DbSet<Comment> Comment { get; set; }
         public DbSet<DbAssessmentReviewData> DbAssessmentReviewData { get; set; }
         public DbSet<DbAssessmentAssessData> DbAssessmentAssessData { get; set; }
         public DbSet<WorkflowInstance> WorkflowInstance { get; set; }
         public DbSet<PrimaryDocumentStatus> PrimaryDocumentStatus { get; set; }
         public DbSet<DatabaseDocumentStatus> DatabaseDocumentStatus { get; set; }
-        public DbSet<LinkedDocuments> LinkedDocument { get; set; }
+        public DbSet<LinkedDocument> LinkedDocument { get; set; }
         public DbSet<OnHold> OnHold { get; set; }
         public DbSet<TaskNote> TaskNote { get; set; }
         public DbSet<HpdUsage> HpdUsage { get; set; }
@@ -43,14 +42,6 @@ namespace WorkflowDatabase.EF
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<WorkflowInstance>().HasKey(x => x.WorkflowInstanceId);
-
-            modelBuilder.Entity<WorkflowInstance>()
-                .HasMany(x => x.Comment);
-
-            modelBuilder.Entity<WorkflowInstance>()
-                .HasMany(x => x.OnHold);
-
             modelBuilder.Entity<WorkflowInstance>()
                 .HasMany(x => x.LinkedDocument)
                 .WithOne()
@@ -88,55 +79,12 @@ namespace WorkflowDatabase.EF
                 .HasForeignKey(p => p.ProcessId);
 
             modelBuilder.Entity<WorkflowInstance>()
-                .HasOne(x => x.DbAssessmentReviewData);
-
-            modelBuilder.Entity<WorkflowInstance>()
-                .HasOne(x => x.DbAssessmentAssessData);
-
-            modelBuilder.Entity<WorkflowInstance>()
                 .HasOne(p => p.AssessmentData)
                 .WithOne()
                 .HasPrincipalKey<WorkflowInstance>(p => p.ProcessId)
                 .HasForeignKey<AssessmentData>(p => p.ProcessId);
 
-            modelBuilder.Entity<ProductAction>()
-                .HasOne(p => p.ProductActionType);
-
-            modelBuilder.Entity<WorkflowInstance>()
-                .HasOne(x => x.TaskNote);
-
-            modelBuilder.Entity<DataImpact>()
-                .HasOne(x => x.HpdUsage);
-
-            modelBuilder.Entity<DbAssessmentReviewData>().HasKey(x => x.DbAssessmentReviewDataId);
-
-            modelBuilder.Entity<DbAssessmentAssessData>().HasKey(x => x.DbAssessmentAssessDataId);
-
-            modelBuilder.Entity<Comments>().HasKey(x => x.CommentId);
-
-            modelBuilder.Entity<LinkedDocuments>().HasKey(x => x.LinkedDocumentId);
-
-            modelBuilder.Entity<PrimaryDocumentStatus>().HasKey(x => x.PrimaryDocumentStatusId);
-
-            modelBuilder.Entity<DatabaseDocumentStatus>().HasKey(x => x.DatabaseDocumentStatusId);
-
-            modelBuilder.Entity<AssessmentData>().HasKey(x => x.AssessmentDataId);
-
-            modelBuilder.Entity<OnHold>().HasKey(x => x.OnHoldId);
-
-            modelBuilder.Entity<TaskNote>().HasKey(x => x.TaskNoteId);
-
-            modelBuilder.Entity<HpdUsage>().HasKey(x => x.HpdUsageId);
-
-            modelBuilder.Entity<ProductActionType>().HasKey(x => x.ProductActionTypeId);
-
-            modelBuilder.Entity<DataImpact>().HasKey(x => x.DataImpactId);
-
-            modelBuilder.Entity<HpdUser>().HasKey(x => x.HpdUserId);
-
-            modelBuilder.Entity<CachedHpdWorkspace>().HasKey(x => x.CachedHpdWorkspaceId);
-
-            modelBuilder.Entity<LinkedDocuments>().Ignore(l => l.ContentServiceUri);
+            modelBuilder.Entity<LinkedDocument>().Ignore(l => l.ContentServiceUri);
 
             modelBuilder.Entity<DatabaseDocumentStatus>().Ignore(l => l.ContentServiceUri);
 

--- a/src/Databases/WorkflowDatabase.Tests/DatabaseIntegrityTests.cs
+++ b/src/Databases/WorkflowDatabase.Tests/DatabaseIntegrityTests.cs
@@ -217,7 +217,7 @@ namespace WorkflowDatabase.Tests
         [Test]
         public void Ensure_Comments_table_prevents_insert_for_no_WorkflowInstance()
         {
-            _dbContext.Comment.AddAsync(new WorkflowDatabase.EF.Models.Comments()
+            _dbContext.Comment.AddAsync(new WorkflowDatabase.EF.Models.Comment()
             {
                 Created = DateTime.Now,
                 ProcessId = 0,
@@ -233,7 +233,7 @@ namespace WorkflowDatabase.Tests
         [Test]
         public void Ensure_LinkedDocument_table_prevents_insert_for_no_ProcessId()
         {
-            _dbContext.LinkedDocument.AddAsync(new LinkedDocuments()
+            _dbContext.LinkedDocument.AddAsync(new LinkedDocument()
             {
                 PrimarySdocId = 1234,
                 LinkType = "Forward",
@@ -337,7 +337,7 @@ namespace WorkflowDatabase.Tests
                 ProductActionTypeId = 1,
                 Name = "CPTS/IA"
             });
-            
+
             _dbContext.SaveChanges();
 
             _dbContext.ProductAction.Add(new ProductAction()
@@ -359,7 +359,7 @@ namespace WorkflowDatabase.Tests
             var ex = Assert.Throws<DbUpdateException>(() => _dbContext.SaveChanges());
             Assert.That(ex.InnerException.Message.Contains("Violation of UNIQUE KEY constraint", StringComparison.OrdinalIgnoreCase));
         }
-        
+
         [Test]
         public void Ensure_productAction_table_allows_duplicate_productActiontypeId_for_different_processId()
         {
@@ -432,7 +432,7 @@ namespace WorkflowDatabase.Tests
 
             var newProductActionCount = _dbContext.SaveChanges();
 
-            Assert.AreEqual(3,newProductActionCount);
+            Assert.AreEqual(3, newProductActionCount);
         }
 
         [Test]

--- a/src/Portal/Portal.UnitTests/SqlEfTests.cs
+++ b/src/Portal/Portal.UnitTests/SqlEfTests.cs
@@ -29,18 +29,18 @@ namespace Portal.UnitTests
         [Test]
         public void Test_Comment_can_be_added_to_db_using_ef()
         {
-            _dbContext.Comment.AddAsync(new WorkflowDatabase.EF.Models.Comments()
+            _dbContext.Comment.AddAsync(new WorkflowDatabase.EF.Models.Comment()
             {
-               CommentId = 1,
-               Created = DateTime.Now,
+                CommentId = 1,
+                Created = DateTime.Now,
                 ProcessId = 9876,
-               Text = "This is a comment",
-               Username = "Me",
-               WorkflowInstanceId = 555
+                Text = "This is a comment",
+                Username = "Me",
+                WorkflowInstanceId = 555
             });
 
             _dbContext.SaveChanges();
-            
+
             Assert.AreEqual(_dbContext.Comment.FirstAsync(c => c.CommentId == 1).Result.Text, "This is a comment");
         }
 

--- a/src/Portal/Portal.UnitTests/TaskNoteTests.cs
+++ b/src/Portal/Portal.UnitTests/TaskNoteTests.cs
@@ -42,7 +42,7 @@ namespace Portal.UnitTests
                 ProcessId = ProcessId,
                 ActivityName = "Review",
                 AssessmentData = new AssessmentData(),
-                Comment = new List<Comments>(),
+                Comments = new List<Comment>(),
                 OnHold = new List<OnHold>(),
                 DbAssessmentReviewData = new DbAssessmentReviewData(),
                 SerialNumber = "123_sn",

--- a/src/Portal/Portal/Helpers/CommentsHelper.cs
+++ b/src/Portal/Portal/Helpers/CommentsHelper.cs
@@ -16,7 +16,7 @@ namespace Portal.Helpers
 
         public async Task AddComment(string comment, int processId, int workflowInstanceId, string userFullName)
         {
-            await _dbContext.Comment.AddAsync(new Comments
+            await _dbContext.Comment.AddAsync(new Comment
             {
                 ProcessId = processId,
                 WorkflowInstanceId = workflowInstanceId,

--- a/src/Portal/Portal/Pages/DbAssessment/Review.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/Review.cshtml.cs
@@ -168,7 +168,7 @@ namespace Portal.Pages.DbAssessment
             {
                 UserFullName = await _userIdentityService.GetFullNameForUser(this.User);
 
-                await _dbContext.Comment.AddAsync(new Comments()
+                await _dbContext.Comment.AddAsync(new Comment()
                 {
                     ProcessId = processId,
                     WorkflowInstanceId = primaryAssignTask.WorkflowInstanceId,

--- a/src/Portal/Portal/Pages/DbAssessment/_Comments.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_Comments.cshtml.cs
@@ -20,7 +20,7 @@ namespace Portal.Pages.DbAssessment
         [BindProperty(SupportsGet = true)]
         public int ProcessId { get; set; }
 
-        public List<Comments> Comments { get; set; }
+        public List<Comment> Comments { get; set; }
 
         private string _userFullName;
         public string UserFullName

--- a/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml.cs
@@ -1,4 +1,8 @@
-﻿using Common.Factories;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Common.Factories;
 using Common.Factories.Interfaces;
 using Common.Messages.Enums;
 using Common.Messages.Events;
@@ -8,13 +12,9 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Options;
 using Portal.Configuration;
 using Portal.HttpClients;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using WorkflowDatabase.EF;
 using WorkflowDatabase.EF.Models;
-using LinkedDocuments = WorkflowDatabase.EF.Models.LinkedDocuments;
+using LinkedDocument = WorkflowDatabase.EF.Models.LinkedDocument;
 
 namespace Portal.Pages.DbAssessment
 {
@@ -28,8 +28,8 @@ namespace Portal.Pages.DbAssessment
 
         [BindProperty(SupportsGet = true)] public int ProcessId { get; set; }
         public AssessmentData Assessment { get; set; }
-        public IEnumerable<LinkedDocuments> LinkedDocuments { get; set; }
-        public IEnumerable<LinkedDocuments> AttachedLinkedDocuments { get; set; }
+        public IEnumerable<LinkedDocument> LinkedDocuments { get; set; }
+        public IEnumerable<LinkedDocument> AttachedLinkedDocuments { get; set; }
         public PrimaryDocumentStatus PrimaryDocumentStatus { get; set; }
         public IEnumerable<DatabaseDocumentStatus> DatabaseDocuments { get; set; }
         public Uri PrimaryDocumentContentServiceUri { get; set; }
@@ -52,7 +52,7 @@ namespace Portal.Pages.DbAssessment
             GetAttachedLinkedDocuments();
             GetDatabaseDocuments();
         }
-        
+
         public async Task<JsonResult> OnGetDatabaseSourceDocumentDataAsync(int sdocId)
         {
             DocumentAssessmentData sourceDocumentData = null;
@@ -173,7 +173,7 @@ namespace Portal.Pages.DbAssessment
                 SourceType = SourceType.Linked
             };
 
-            await _eventServiceApiClient.PostEvent(nameof(InitiateSourceDocumentRetrievalEvent),docRetrievalEvent);
+            await _eventServiceApiClient.PostEvent(nameof(InitiateSourceDocumentRetrievalEvent), docRetrievalEvent);
 
             return StatusCode(200);
             // TODO: Log!

--- a/src/Portal/Portal/Pages/Index.cshtml.cs
+++ b/src/Portal/Portal/Pages/Index.cshtml.cs
@@ -44,7 +44,7 @@ namespace Portal.Pages
         public async Task OnGetAsync()
         {
             var workflows = await _dbContext.WorkflowInstance
-                .Include(c => c.Comment)
+                .Include(c => c.Comments)
                 .Include(a => a.AssessmentData)
                 .Include(d => d.DbAssessmentReviewData)
                 .Include(t => t.TaskNote)

--- a/src/Portal/Portal/ViewModels/TaskViewModel.cs
+++ b/src/Portal/Portal/ViewModels/TaskViewModel.cs
@@ -20,6 +20,6 @@ namespace Portal.ViewModels
         public string DbAssessmentReviewDataVerifier { get; set; }
         public string Team { get; set; }
         public string TaskNoteText { get; set; }
-        public List<Comments> Comment { get; set; }
+        public List<Comment> Comment { get; set; }
     }
 }

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Handlers/GetBackwardDocumentLinksCommandHandler.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Handlers/GetBackwardDocumentLinksCommandHandler.cs
@@ -31,7 +31,7 @@ namespace SourceDocumentCoordinator.Handlers
             {
                 var documentAssessmentData = await _dataServiceApiClient.GetAssessmentData(linkedDocId);
 
-                var linkedDocument = new LinkedDocuments
+                var linkedDocument = new LinkedDocument
                 {
                     ProcessId = message.ProcessId,
                     PrimarySdocId = message.SourceDocumentId,

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Handlers/GetForwardDocumentLinksCommandHandler.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Handlers/GetForwardDocumentLinksCommandHandler.cs
@@ -30,7 +30,7 @@ namespace SourceDocumentCoordinator.Handlers
             {
                 var documentAssessmentData = await _dataServiceApiClient.GetAssessmentData(linkedDocId);
 
-                var linkedDocument = new LinkedDocuments
+                var linkedDocument = new LinkedDocument
                 {
                     ProcessId = message.ProcessId,
                     PrimarySdocId = message.SourceDocumentId,

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Handlers/GetSepDocumentLinksCommandHandler.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Handlers/GetSepDocumentLinksCommandHandler.cs
@@ -28,7 +28,7 @@ namespace SourceDocumentCoordinator.Handlers
             {
                 var documentAssessmentData = await _dataServiceApiClient.GetAssessmentData(documentObject.Id);
 
-                var linkedDocument = new LinkedDocuments
+                var linkedDocument = new LinkedDocument
                 {
                     ProcessId = message.ProcessId,
                     PrimarySdocId = message.SourceDocumentId,

--- a/src/WorkflowCoordinator/WorkflowCoordinator/MappingProfiles/AssessmentDataMappingProfile.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/MappingProfiles/AssessmentDataMappingProfile.cs
@@ -22,7 +22,7 @@ namespace WorkflowCoordinator.MappingProfiles
                 .ForMember(destination => destination.RsdraNumber,
                     opts => opts.MapFrom(source => source.SourceName));
 
-            CreateMap<DocumentAssessmentData, Comments>()
+            CreateMap<DocumentAssessmentData, Comment>()
                 .ForMember(destination => destination.Text,
                     opts => opts.MapFrom(source => source.Notes));
         }

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Sagas/StartDbAssessmentSaga.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Sagas/StartDbAssessmentSaga.cs
@@ -1,22 +1,21 @@
-﻿using Common.Helpers;
+﻿using System;
+using System.Threading.Tasks;
+using AutoMapper;
+using Common.Helpers;
+using Common.Messages.Commands;
+using Common.Messages.Enums;
+using Common.Messages.Events;
+using DataServices.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using NServiceBus;
 using NServiceBus.Logging;
-using System;
-using System.Linq;
-using AutoMapper;
-using DataServices.Models;
 using WorkflowCoordinator.Config;
 using WorkflowCoordinator.HttpClients;
 using WorkflowCoordinator.Messages;
 using WorkflowDatabase.EF;
 using WorkflowDatabase.EF.Models;
 using Task = System.Threading.Tasks.Task;
-using System.Threading.Tasks;
-using Common.Messages.Commands;
-using Common.Messages.Enums;
-using Common.Messages.Events;
 
 namespace WorkflowCoordinator.Sagas
 {
@@ -121,7 +120,7 @@ namespace WorkflowCoordinator.Sagas
 
             // Add assessment data and any comments to DB, after auto mapping it
             var mappedAssessmentData = _mapper.Map<DocumentAssessmentData, AssessmentData>(assessmentData);
-            var mappedComments = _mapper.Map<DocumentAssessmentData, Comments>(assessmentData);
+            var mappedComments = _mapper.Map<DocumentAssessmentData, Comment>(assessmentData);
 
             mappedAssessmentData.ProcessId = message.ProcessId;
             mappedComments.WorkflowInstanceId = message.WorkflowInstanceId;


### PR DESCRIPTION
- Fix consistency on non-plural entities to use conventions.

Now with conventions being followed we can:

- Remove unnecessary attributes.
- Remove all unnecessary  EF fluent builder keys in the workflow DbContext.

Still need more discussion on the ignores and alt. key for relationships: 

- We're using EF models in our Razor pages. Shouldn't need the display name attribute on EF models, or fluent builder being used to ignore properties. Consider mapping to view models in places.
- The number of relationships we are having to force on process ID in the fluent builder suggests we need to rethink our keys and relationships.