### PR TITLE
Add SQL username and pwd to Serilog logging setup for Event Service

### DIFF
--- a/src/EventServices/EventService/Config/StartupSecretsConfig.cs
+++ b/src/EventServices/EventService/Config/StartupSecretsConfig.cs
@@ -4,5 +4,7 @@
     {
         public string NsbDataSource { get; set; }
         public string NsbInitialCatalog { get; set; }
+        public string SqlLoggingUsername { get; set; }
+        public string SqlLoggingPassword { get; set; }
     }
 }

--- a/src/EventServices/EventService/LoggingHelper.cs
+++ b/src/EventServices/EventService/LoggingHelper.cs
@@ -11,12 +11,13 @@ namespace EventService
 {
     public class LoggingHelper
     {
-        public static void SetupLogging(bool isLocalDb, StartupLoggingConfig startupLoggingConfig)
+        public static void SetupLogging(bool isLocalDb, StartupLoggingConfig startupLoggingConfig, StartupSecretsConfig startupSecretsConfig)
         {
             var loggingConnectionString = DatabasesHelpers.BuildSqlConnectionString(
                 isLocalDb,
                 isLocalDb ? startupLoggingConfig.LocalDbServer : startupLoggingConfig.WorkflowDbServer,
-                isLocalDb ? startupLoggingConfig.LocalDbName : startupLoggingConfig.WorkflowDbName
+                isLocalDb ? startupLoggingConfig.LocalDbName : startupLoggingConfig.WorkflowDbName,
+                startupSecretsConfig.SqlLoggingUsername, startupSecretsConfig.SqlLoggingPassword
             );
 
             Enum.TryParse(startupLoggingConfig.Level, out LogEventLevel logLevel);

--- a/src/EventServices/EventService/Startup.cs
+++ b/src/EventServices/EventService/Startup.cs
@@ -35,7 +35,11 @@ namespace EventService
             var startupLoggingConfig = new StartupLoggingConfig();
             Configuration.GetSection("logging").Bind(startupLoggingConfig);
 
-            LoggingHelper.SetupLogging(isLocalDb, startupLoggingConfig);
+            var startupSecretsConfig = new StartupSecretsConfig();
+            Configuration.GetSection("NsbDbSection").Bind(startupSecretsConfig);
+            Configuration.GetSection("LoggingDbSection").Bind(startupSecretsConfig);
+
+            LoggingHelper.SetupLogging(isLocalDb, startupLoggingConfig, startupSecretsConfig);
 
             services.AddControllers();
             services.AddMvc();
@@ -56,9 +60,6 @@ namespace EventService
             Configuration.GetSection("urls").Bind(startupConfig);
             Configuration.GetSection("databases").Bind(startupConfig);
             Configuration.GetSection("nsb").Bind(startupConfig);
-
-            var startupSecretsConfig = new StartupSecretsConfig();
-            Configuration.GetSection("NsbDbSection").Bind(startupSecretsConfig);
 
             string connectionString = null;
 


### PR DESCRIPTION
- Pass SQL username and password through to connection string that will be used by Serilog during startup

Co-authored-by: Benjamin Ilo <42581204+247benji@users.noreply.github.com>