### PR TITLE
Fix user setting on Index page

### DIFF
--- a/src/Portal/Portal/Pages/Index.cshtml.cs
+++ b/src/Portal/Portal/Pages/Index.cshtml.cs
@@ -174,7 +174,7 @@ namespace Portal.Pages
 
         private void SetUsersOnTask(WorkflowInstance instance, TaskViewModel task)
         {
-            task.Reviewer = instance.DbAssessmentReviewData.Reviewer;
+            task.Reviewer = instance.DbAssessmentReviewData?.Reviewer;
 
             switch (task.TaskStage)
             {


### PR DESCRIPTION
- Check DbAssessmentReviewData for null before reading a property from it

Co-authored-by: Bonnie Poole <51318811+bonpoole@users.noreply.github.com>