### PR TITLE
Max Size issue fixed in Notes

### DIFF
--- a/src/Databases/NCNEWorkflowDatabase/Tables/NcneTaskNote.sql
+++ b/src/Databases/NCNEWorkflowDatabase/Tables/NcneTaskNote.sql
@@ -1,11 +1,11 @@
 ﻿CREATE TABLE [dbo].[NcneTaskNote]
 (
 	[TaskNoteId] INT NOT NULL PRIMARY KEY IDENTITY, 
-    [ProcessId] INT NOT NULL, 
-    [Text] NVARCHAR(4000) NOT NULL, 
-    [CreatedByUsername] NVARCHAR(255) NOT NULL, 
-    [Created] DATETIME NOT NULL, 
-    [LastModified] DATETIME NOT NULL, 
-    [LastModifiedByUsername] NVARCHAR(255) NOT NULL , 
-    CONSTRAINT [FK_TaskNote_ProcessId] FOREIGN KEY ([ProcessId]) REFERENCES [NcneTaskInfo]([ProcessId])
+	[ProcessId] INT NOT NULL, 
+	[Text] NVARCHAR(MAX) NOT NULL, 
+	[CreatedByUsername] NVARCHAR(255) NOT NULL, 
+	[Created] DATETIME NOT NULL, 
+	[LastModified] DATETIME NOT NULL, 
+	[LastModifiedByUsername] NVARCHAR(255) NOT NULL , 
+	CONSTRAINT [FK_TaskNote_ProcessId] FOREIGN KEY ([ProcessId]) REFERENCES [NcneTaskInfo]([ProcessId])
 )

--- a/src/NCNEPortal/Pages/Index.cshtml
+++ b/src/NCNEPortal/Pages/Index.cshtml
@@ -136,7 +136,7 @@
                 </div>
                 <div class="modal-body">
                     <div id="modal-body">
-                        <textarea style="height: 100px;" id="txtNote" name="taskNote" class="form-control"></textarea>
+                        <textarea style="height: 100px;" maxlength="4000" id="txtNote" name="taskNote" class="form-control"></textarea>
                         <input type="hidden" id="hdnProcessId" name="processId" />
                         <br />
                         <div id="editTaskNoteError"></div>


### PR DESCRIPTION
MaxLength is increased to 4000, but it still accepts around 4035 characters.
So, we had to increase the database field size, in which nvarchar don't allow more than 4000. 
So, changed the size to Max. Since the limit is set in UI, the field will not get more than 4035 characters.