### PR TITLE
Add resilience to Event Service NSB Publish.

### DIFF
--- a/src/EventServices/EventService.UnitTests/EventService.UnitTests.csproj
+++ b/src/EventServices/EventService.UnitTests/EventService.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
 
     <IsPackable>false</IsPackable>
@@ -13,11 +13,6 @@
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EventServices/EventService/EventService.csproj
+++ b/src/EventServices/EventService/EventService.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.2.0" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.6.1" />
     <PackageReference Include="NServiceBus.SqlServer" Version="4.3.1" />
+    <PackageReference Include="Polly" Version="7.2.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.1.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0" />

--- a/src/EventServices/EventService/EventService.csproj
+++ b/src/EventServices/EventService/EventService.csproj
@@ -1,27 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.0" />
     <PackageReference Include="NServiceBus" Version="7.2.0" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.2.0" />
-    <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.6.0" />
+    <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.6.1" />
     <PackageReference Include="NServiceBus.SqlServer" Version="4.3.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.1.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.0.0-rc4" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.6.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Used Polly package
- Returning 503 on failure to clarify to caller that service is idempotent and it is safe for them to retry the POST.
- To keep REST response reasonable have (initially hard-coded) 3 retries at 2, 4 and 6 seconds, which should be enough to cover any transient faults with the database.

Need to keep service idempotent and respond to caller in a reasonable time to retry. If caller does not automate retries against the API then they when the error surfaces we can replay the event firing via Swagger as the JSON is already logged.

If we decide that caller can fire and forget without any knowledge of error then we can build more into this retry.

Have resisted urge to refactor all those try/catch for now :)