### PR TITLE
Check that Chrome Driver environment variable exists

### DIFF
--- a/src/NCNEPortal.TestAutomation.Framework/WebDriverSupport.cs
+++ b/src/NCNEPortal.TestAutomation.Framework/WebDriverSupport.cs
@@ -25,7 +25,10 @@ namespace NCNEPortal.TestAutomation.Framework
         [BeforeScenario(Order = 0)]
         public void InitializeWebDriver()
         {
-            _webDriver = new ChromeDriver(Environment.GetEnvironmentVariable("ChromeWebDriver"));
+            var chromeDriverDirectory = Environment.GetEnvironmentVariable("ChromeWebDriver");
+            if (string.IsNullOrEmpty(chromeDriverDirectory)) throw new ApplicationException("Missing environment variable: ChromeWebDriver");
+
+            _webDriver = new ChromeDriver(chromeDriverDirectory);
             _objectContainer.RegisterInstanceAs(_webDriver);
         }
 

--- a/src/Portal.TestAutomation.Framework/Setup/WebDriverSupport.cs
+++ b/src/Portal.TestAutomation.Framework/Setup/WebDriverSupport.cs
@@ -19,7 +19,10 @@ namespace Portal.TestAutomation.Framework.Driver
         [BeforeScenario(Order = 0)]
         public void InitializeWebDriver()
         {
-            var webDriver = new ChromeDriver(Environment.GetEnvironmentVariable("ChromeWebDriver"));
+            var chromeDriverDirectory = Environment.GetEnvironmentVariable("ChromeWebDriver");
+            if (string.IsNullOrEmpty(chromeDriverDirectory)) throw new ApplicationException("Missing environment variable: ChromeWebDriver");
+
+            var webDriver = new ChromeDriver(chromeDriverDirectory);
             _objectContainer.RegisterInstanceAs<IWebDriver>(webDriver);
         }
     }


### PR DESCRIPTION
A descriptive exception is now thrown when the ChromeWebDriver environment variable is missing