### PR TITLE
Assigning to a reviewer on review page

### DIFF
--- a/src/Databases/WorkflowDatabase.EF/Models/DbAssessmentAssessData.cs
+++ b/src/Databases/WorkflowDatabase.EF/Models/DbAssessmentAssessData.cs
@@ -3,7 +3,7 @@ using WorkflowDatabase.EF.Interfaces;
 
 namespace WorkflowDatabase.EF.Models
 {
-    public class DbAssessmentAssessData : ITaskData, IProductActionData
+    public class DbAssessmentAssessData : ITaskData, IProductActionData, IOperatorData
     {
         public int DbAssessmentAssessDataId { get; set; }
         public int ProcessId { get; set; }

--- a/src/Databases/WorkflowDatabase.EF/Models/DbAssessmentReviewData.cs
+++ b/src/Databases/WorkflowDatabase.EF/Models/DbAssessmentReviewData.cs
@@ -3,7 +3,7 @@ using WorkflowDatabase.EF.Interfaces;
 
 namespace WorkflowDatabase.EF.Models
 {
-    public class DbAssessmentReviewData : ITaskData
+    public class DbAssessmentReviewData : ITaskData, IOperatorData
     {
         public int DbAssessmentReviewDataId { get; set; }
         public int ProcessId { get; set; }

--- a/src/Databases/WorkflowDatabase.EF/Models/DbAssessmentVerifyData.cs
+++ b/src/Databases/WorkflowDatabase.EF/Models/DbAssessmentVerifyData.cs
@@ -3,7 +3,7 @@ using WorkflowDatabase.EF.Interfaces;
 
 namespace WorkflowDatabase.EF.Models
 {
-    public class DbAssessmentVerifyData : ITaskData, IProductActionData
+    public class DbAssessmentVerifyData : ITaskData, IProductActionData, IOperatorData
     {
         public int DbAssessmentVerifyDataId { get; set; }
         public int ProcessId { get; set; }

--- a/src/Databases/WorkflowDatabase.EF/Models/IOperatorData.cs
+++ b/src/Databases/WorkflowDatabase.EF/Models/IOperatorData.cs
@@ -1,0 +1,11 @@
+namespace WorkflowDatabase.EF.Models
+{
+    public interface IOperatorData
+    {
+        string Reviewer { get; set; }
+
+        string Verifier { get; set; }
+
+        string Assessor { get; set; }
+    }
+}

--- a/src/Databases/WorkflowDatabase.EF/WorkflowStage.cs
+++ b/src/Databases/WorkflowDatabase.EF/WorkflowStage.cs
@@ -1,0 +1,9 @@
+﻿namespace WorkflowDatabase.EF
+{
+    public enum WorkflowStage
+    {
+        Review,
+        Assess,
+        Verify
+    }
+}

--- a/src/Portal/Portal/Helpers/IPageValidationHelper.cs.cs
+++ b/src/Portal/Portal/Helpers/IPageValidationHelper.cs.cs
@@ -13,10 +13,11 @@ namespace Portal.Helpers
         /// <param name="additionalAssignedTasks"></param>
         /// <param name="validationErrorMessages"></param>
         /// <returns></returns>
-        bool ValidateReviewPage(
+        Task<bool> ValidateReviewPage(
             DbAssessmentReviewData primaryAssignedTask,
             List<DbAssessmentAssignTask> additionalAssignedTasks,
-            List<string> validationErrorMessages);
+            List<string> validationErrorMessages,
+            string Reviewer);
 
         /// <summary>
         /// Used in Assess page
@@ -31,13 +32,13 @@ namespace Portal.Helpers
         /// <param name="validationErrorMessages"></param>
         /// <returns></returns>
         Task<bool> ValidateAssessPage(
-            string ion, 
-            string activityCode, 
+            string ion,
+            string activityCode,
             string sourceCategory,
             string taskType,
             string verifier,
-            List<ProductAction> recordProductAction, 
-            List<DataImpact> dataImpacts, 
+            List<ProductAction> recordProductAction,
+            List<DataImpact> dataImpacts,
             List<string> validationErrorMessages);
 
 

--- a/src/Portal/Portal/Pages/DbAssessment/Assess.cshtml
+++ b/src/Portal/Portal/Pages/DbAssessment/Assess.cshtml
@@ -60,7 +60,7 @@
 
     <input type="hidden" id="hdnProcessId" value="@Model.ProcessId" />
     <input type="hidden" asp-for="ProcessId" />
-    <input type="hidden" id="pageIdentity" value="Assess" />
+    <input type="hidden" id="pageIdentity" value="@Model.WorkflowStage.ToString()" />
 
     <div id="taskInformation"></div>
     <div id="taskInformationError"></div>

--- a/src/Portal/Portal/Pages/DbAssessment/Assess.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/Assess.cshtml.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -9,14 +8,11 @@ using Common.Messages.Events;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using Portal.Auth;
 using Portal.Helpers;
 using Portal.HttpClients;
-using Portal.Models;
 using Serilog.Context;
 using WorkflowDatabase.EF;
 using WorkflowDatabase.EF.Models;
@@ -111,6 +107,7 @@ namespace Portal.Pages.DbAssessment
 
             var currentAssessData = await _dbContext.DbAssessmentAssessData.FirstAsync(r => r.ProcessId == processId);
             OperatorsModel = _OperatorsModel.GetOperatorsData(currentAssessData);
+            OperatorsModel.ParentPage = WorkflowStage.Assess;
 
             await GetOnHoldData(processId);
         }

--- a/src/Portal/Portal/Pages/DbAssessment/Assess.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/Assess.cshtml.cs
@@ -108,7 +108,10 @@ namespace Portal.Pages.DbAssessment
             //TODO: Read operators from DB
 
             ProcessId = processId;
-            OperatorsModel = await GetOperatorsData(processId);
+
+            var currentAssessData = await _dbContext.DbAssessmentAssessData.FirstAsync(r => r.ProcessId == processId);
+            OperatorsModel = _OperatorsModel.GetOperatorsData(currentAssessData);
+
             await GetOnHoldData(processId);
         }
 
@@ -298,27 +301,6 @@ namespace Portal.Pages.DbAssessment
                     workflowInstance.AssessmentData.PrimarySdocId,
                     comment);
             }
-        }
-
-        private async Task<_OperatorsModel> GetOperatorsData(int processId)
-        {
-            if (!System.IO.File.Exists(@"Data\Users.json")) throw new FileNotFoundException(@"Data\Users.json");
-
-            var jsonString = System.IO.File.ReadAllText(@"Data\Users.json");
-            var users = JsonConvert.DeserializeObject<IEnumerable<Assessor>>(jsonString)
-                .Select(u => u.Name)
-                .ToList();
-
-            var currentAssess = await _dbContext.DbAssessmentAssessData.FirstAsync(r => r.ProcessId == processId);
-
-
-            return new _OperatorsModel
-            {
-                Reviewer = currentAssess.Reviewer ?? "Unknown",
-                Assessor = currentAssess.Assessor ?? "Unknown",
-                Verifier = currentAssess.Verifier ?? "",
-                Verifiers = new SelectList(users)
-            };
         }
 
         private async Task GetOnHoldData(int processId)

--- a/src/Portal/Portal/Pages/DbAssessment/Assess.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/Assess.cshtml.cs
@@ -66,6 +66,8 @@ namespace Portal.Pages.DbAssessment
         [BindProperty]
         public string ProjectName { get; set; }
 
+        public WorkflowStage WorkflowStage { get; set; }
+
         [BindProperty]
         public List<DataImpact> DataImpacts { get; set; }
 
@@ -107,8 +109,7 @@ namespace Portal.Pages.DbAssessment
 
             var currentAssessData = await _dbContext.DbAssessmentAssessData.FirstAsync(r => r.ProcessId == processId);
             OperatorsModel = _OperatorsModel.GetOperatorsData(currentAssessData);
-            OperatorsModel.ParentPage = WorkflowStage.Assess;
-
+            OperatorsModel.ParentPage = WorkflowStage = WorkflowStage.Assess;
             await GetOnHoldData(processId);
         }
 

--- a/src/Portal/Portal/Pages/DbAssessment/Review.cshtml
+++ b/src/Portal/Portal/Pages/DbAssessment/Review.cshtml
@@ -64,6 +64,8 @@
     <div id="taskInformation"></div>
     <div id="taskInformationError"></div>
 
+    @await Html.PartialAsync("_Operators", Model.OperatorsModel).ConfigureAwait(false)
+
     <div id="sourceDocuments"></div>
     <div id="sourceDocumentsError"></div>
 

--- a/src/Portal/Portal/Pages/DbAssessment/Review.cshtml
+++ b/src/Portal/Portal/Pages/DbAssessment/Review.cshtml
@@ -1,4 +1,5 @@
 ﻿@page
+@using WorkflowDatabase.EF
 @model Portal.Pages.DbAssessment.ReviewModel
 @{
     ViewData["Title"] = "Review";
@@ -59,7 +60,7 @@
 <form id="frmReviewPage" method="post">
 
     <input type="hidden" asp-for="ProcessId" id="hdnProcessId" />
-    <input type="hidden" id="pageIdentity" value="Review" />
+    <input type="hidden" id="pageIdentity" value="@Model.WorkflowStage.ToString()" />
 
     <div id="taskInformation"></div>
     <div id="taskInformationError"></div>

--- a/src/Portal/Portal/Pages/DbAssessment/Review.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/Review.cshtml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -9,11 +10,14 @@ using Common.Messages.Events;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using Portal.Auth;
 using Portal.Helpers;
 using Portal.HttpClients;
+using Portal.Models;
 using Serilog.Context;
 using WorkflowDatabase.EF;
 using WorkflowDatabase.EF.Models;
@@ -49,6 +53,8 @@ namespace Portal.Pages.DbAssessment
         [BindProperty]
         public List<DbAssessmentAssignTask> AdditionalAssignedTasks { get; set; }
 
+        public _OperatorsModel OperatorsModel { get; set; }
+
         public List<string> ValidationErrorMessages { get; set; }
 
         private string _userFullName;
@@ -82,6 +88,10 @@ namespace Portal.Pages.DbAssessment
         public async Task OnGet(int processId)
         {
             ProcessId = processId;
+
+            var currentAssessData = await _dbContext.DbAssessmentAssessData.FirstAsync(r => r.ProcessId == processId);
+            OperatorsModel = _OperatorsModel.GetOperatorsData(currentAssessData);
+
             await GetOnHoldData(processId);
         }
 

--- a/src/Portal/Portal/Pages/DbAssessment/Review.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/Review.cshtml.cs
@@ -91,6 +91,7 @@ namespace Portal.Pages.DbAssessment
 
             var currentReviewData = await _dbContext.DbAssessmentReviewData.FirstAsync(r => r.ProcessId == processId);
             OperatorsModel = _OperatorsModel.GetOperatorsData(currentReviewData);
+            OperatorsModel.ParentPage = WorkflowStage.Review;
 
             await GetOnHoldData(processId);
         }

--- a/src/Portal/Portal/Pages/DbAssessment/Review.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/Review.cshtml.cs
@@ -55,6 +55,8 @@ namespace Portal.Pages.DbAssessment
 
         public _OperatorsModel OperatorsModel { get; set; }
 
+        public WorkflowStage WorkflowStage { get; set; }
+
         public List<string> ValidationErrorMessages { get; set; }
 
         private string _userFullName;
@@ -91,7 +93,7 @@ namespace Portal.Pages.DbAssessment
 
             var currentReviewData = await _dbContext.DbAssessmentReviewData.FirstAsync(r => r.ProcessId == processId);
             OperatorsModel = _OperatorsModel.GetOperatorsData(currentReviewData);
-            OperatorsModel.ParentPage = WorkflowStage.Review;
+            OperatorsModel.ParentPage = WorkflowStage = WorkflowStage.Review;
 
             await GetOnHoldData(processId);
         }

--- a/src/Portal/Portal/Pages/DbAssessment/Verify.cshtml
+++ b/src/Portal/Portal/Pages/DbAssessment/Verify.cshtml
@@ -66,7 +66,7 @@
 
     <input type="hidden" id="hdnProcessId" value="@Model.ProcessId" />
     <input type="hidden" asp-for="ProcessId" />
-    <input type="hidden" id="pageIdentity" value="Verify" />
+    <input type="hidden" id="pageIdentity" value="@Model.WorkflowStage.ToString()" />
 
     <div id="taskInformation"></div>
     <div id="taskInformationError"></div>

--- a/src/Portal/Portal/Pages/DbAssessment/Verify.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/Verify.cshtml.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -9,14 +8,11 @@ using Common.Messages.Events;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using Portal.Auth;
 using Portal.Helpers;
 using Portal.HttpClients;
-using Portal.Models;
 using Serilog.Context;
 using WorkflowDatabase.EF;
 using WorkflowDatabase.EF.Models;
@@ -102,7 +98,10 @@ namespace Portal.Pages.DbAssessment
         public async Task OnGet(int processId)
         {
             ProcessId = processId;
-            OperatorsModel = SetOperatorsDummyData();
+
+            var currentAssessData = await _dbContext.DbAssessmentAssessData.FirstAsync(r => r.ProcessId == processId);
+            OperatorsModel = _OperatorsModel.GetOperatorsData(currentAssessData);
+
             await GetOnHoldData(processId);
         }
 
@@ -311,24 +310,6 @@ namespace Portal.Pages.DbAssessment
                     workflowInstance.AssessmentData.PrimarySdocId,
                     comment);
             }
-        }
-
-        private _OperatorsModel SetOperatorsDummyData()
-        {
-            if (!System.IO.File.Exists(@"Data\Users.json")) throw new FileNotFoundException(@"Data\Users.json");
-
-            var jsonString = System.IO.File.ReadAllText(@"Data\Users.json");
-            var users = JsonConvert.DeserializeObject<IEnumerable<Assessor>>(jsonString)
-                .Select(u => u.Name)
-                .ToList();
-
-            return new _OperatorsModel
-            {
-                Reviewer = "Greg Williams",
-                Assessor = "Peter Bates",
-                Verifier = "Matt Stoodley",
-                Verifiers = new SelectList(users)
-            };
         }
 
         private async Task GetOnHoldData(int processId)

--- a/src/Portal/Portal/Pages/DbAssessment/Verify.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/Verify.cshtml.cs
@@ -101,6 +101,7 @@ namespace Portal.Pages.DbAssessment
 
             var currentAssessData = await _dbContext.DbAssessmentAssessData.FirstAsync(r => r.ProcessId == processId);
             OperatorsModel = _OperatorsModel.GetOperatorsData(currentAssessData);
+            OperatorsModel.ParentPage = WorkflowStage.Verify;
 
             await GetOnHoldData(processId);
         }

--- a/src/Portal/Portal/Pages/DbAssessment/Verify.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/Verify.cshtml.cs
@@ -71,6 +71,8 @@ namespace Portal.Pages.DbAssessment
         [BindProperty]
         public string SelectedCarisWorkspace { get; set; }
 
+        public WorkflowStage WorkflowStage { get; set; }
+
         [BindProperty]
         public string ProjectName { get; set; }
 
@@ -101,7 +103,7 @@ namespace Portal.Pages.DbAssessment
 
             var currentAssessData = await _dbContext.DbAssessmentAssessData.FirstAsync(r => r.ProcessId == processId);
             OperatorsModel = _OperatorsModel.GetOperatorsData(currentAssessData);
-            OperatorsModel.ParentPage = WorkflowStage.Verify;
+            OperatorsModel.ParentPage = WorkflowStage = WorkflowStage.Verify;
 
             await GetOnHoldData(processId);
         }

--- a/src/Portal/Portal/Pages/DbAssessment/_Operators.cshtml
+++ b/src/Portal/Portal/Pages/DbAssessment/_Operators.cshtml
@@ -6,29 +6,53 @@
     <h6>Operators</h6>
 
     <div class="col-12">
-        <div class="card-body p-2">
-            <div class="row justify-content-center align-items-center">
-                <div class="col-4">
-                    <div class="row align-items-center">
-                        <div class="col-5">@Html.LabelFor(model => model.Reviewer, new { @class = "col-form-label" })</div>
-                        <div class="col-5">@Html.DisplayFor(model => model.Reviewer)</div>
+        <div class="card-body p-2" id="operators">
+            <div class="row">
+                <div class="operator col-4">
+                    <div class="row justify-content-start">
+                        <div class="col-3 d-flex justify-content-start pr-0">@Html.LabelFor(model => model.Reviewer, new { @class = "col-form-label" })</div>
+                        <div class="col-8">
+                            <div class="text-input-wrap">
+                                @Html.TextBoxFor(model => model.Reviewer, "", new { @class = "typeahead tt-query form-text-input", autocomplete = "off", spellcheck = "false" })
+                            </div>
+                            @*<div id="assignTaskErrorMessages" class="dialog error collapse mt-3 pb-1">
+                                    <h5 class="mb-3">
+                                        <i class="fas fa-times-circle" style="font-size: 1rem;"></i>
+                                        <span>There's a problem</span>
+                                    </h5>
+                                    <ol id="assignTaskErrorList" class="error-list"></ol>
+                                </div>*@
+
+
+                        </div>
+
                     </div>
                 </div>
-                <div class="col-4">
-                    <div class="row align-items-center">
-                        <div class="col-4">@Html.LabelFor(model => model.Assessor, new { @class = "col-form-label" })</div>
-                        <div class="col-7">
-                                <input id="Assessor" type="text" asp-for="Assessor" class="form-text-input" autocomplete="off" spellcheck="false" disabled>
-                            </div>
+                <div class="operator col-4">
+                    <div class="row justify-content-start">
+                        <div class="col-3 d-flex justify-content-start pr-0">@Html.LabelFor(model => model.Assessor, new { @class = "col-form-label" })</div>
+                        <div class="col-8">
+                            <input id="Assessor" type="text" asp-for="Assessor" class="form-text-input" autocomplete="off" spellcheck="false" disabled>
                         </div>
+                    </div>
                 </div>
-                <div class="col-4">
-                    <div class="row align-items-center">
-                        <div class="col-4">@Html.LabelFor(model => model.Verifier, new { @class = "col-form-label" })</div>
+                <div class="operator col-4">
+                    <div class="row justify-content-start">
+                        <div class="col-3 d-flex justify-content-start pr-0">@Html.LabelFor(model => model.Verifier, new { @class = "col-form-label" })</div>
                         <div class="col-8">@Html.DropDownListFor(model => model.Verifier, Model.Verifiers, "", new { @class = "form-control" })</div>
                     </div>
                 </div>
 
+            </div>
+            <div class="row justify-content-start">
+
+                <div id="operatorsErrorMessages" class="dialog error collapse mt-3 pb-1">
+                    <h5 class="mb-3">
+                        <i class="fas fa-times-circle" style="font-size: 1rem;"></i>
+                        <span>There's a problem</span>
+                    </h5>
+                    <ol id="operatorsErrorList" class="error-list"></ol>
+                </div>
             </div>
         </div>
     </div>

--- a/src/Portal/Portal/Pages/DbAssessment/_Operators.cshtml
+++ b/src/Portal/Portal/Pages/DbAssessment/_Operators.cshtml
@@ -13,17 +13,15 @@
                         <div class="col-3 d-flex justify-content-start pr-0">@Html.LabelFor(model => model.Reviewer, new { @class = "col-form-label" })</div>
                         <div class="col-8">
                             <div class="text-input-wrap">
-                                @Html.TextBoxFor(model => model.Reviewer, "", new { @class = "typeahead tt-query form-text-input", autocomplete = "off", spellcheck = "false" })
+                                @if (string.IsNullOrEmpty(Model.Reviewer))
+                                {
+                                    @Html.TextBoxFor(model => model.Reviewer, "", new { @class = "typeahead tt-query form-text-input", autocomplete = "off", spellcheck = "false" })
+                                }
+                                else
+                                {
+                                    @Html.TextBoxFor(model => model.Reviewer, "", new { @disabled = "disabled", @class = "typeahead tt-query form-text-input" })
+                                }
                             </div>
-                            @*<div id="assignTaskErrorMessages" class="dialog error collapse mt-3 pb-1">
-                                    <h5 class="mb-3">
-                                        <i class="fas fa-times-circle" style="font-size: 1rem;"></i>
-                                        <span>There's a problem</span>
-                                    </h5>
-                                    <ol id="assignTaskErrorList" class="error-list"></ol>
-                                </div>*@
-
-
                         </div>
 
                     </div>

--- a/src/Portal/Portal/Pages/DbAssessment/_Operators.cshtml
+++ b/src/Portal/Portal/Pages/DbAssessment/_Operators.cshtml
@@ -1,4 +1,5 @@
-﻿@model Portal.Pages.DbAssessment._OperatorsModel
+﻿@using WorkflowDatabase.EF
+@model Portal.Pages.DbAssessment._OperatorsModel
 @*
     For more information on enabling MVC for empty projects, visit http://go.microsoft.com/fwlink/?LinkID=397860
 *@
@@ -13,7 +14,8 @@
                         <div class="col-3 d-flex justify-content-start pr-0">@Html.LabelFor(model => model.Reviewer, new { @class = "col-form-label" })</div>
                         <div class="col-8">
                             <div class="text-input-wrap">
-                                @if (string.IsNullOrEmpty(Model.Reviewer))
+
+                                @if (Model.ParentPage == WorkflowStage.Review)
                                 {
                                     @Html.TextBoxFor(model => model.Reviewer, "", new { @class = "typeahead tt-query form-text-input", autocomplete = "off", spellcheck = "false" })
                                 }

--- a/src/Portal/Portal/Pages/DbAssessment/_Operators.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_Operators.cshtml.cs
@@ -1,6 +1,12 @@
-﻿using System.ComponentModel;
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using Newtonsoft.Json;
+using Portal.Models;
+using WorkflowDatabase.EF.Models;
 
 namespace Portal.Pages.DbAssessment
 {
@@ -18,9 +24,30 @@ namespace Portal.Pages.DbAssessment
 
         public SelectList Verifiers { get; set; }
 
+        public SelectList Reviewers { get; set; }
+
         public void OnGet()
         {
 
+        }
+
+        internal static _OperatorsModel GetOperatorsData(DbAssessmentAssessData currentAssessData)
+        {
+            if (!System.IO.File.Exists(@"Data\Users.json")) throw new FileNotFoundException(@"Data\Users.json");
+
+            var jsonString = System.IO.File.ReadAllText(@"Data\Users.json");
+            var users = JsonConvert.DeserializeObject<IEnumerable<Assessor>>(jsonString)
+                .Select(u => u.Name)
+                .ToList();
+
+            return new _OperatorsModel
+            {
+                Reviewer = currentAssessData.Reviewer ?? "",
+                Assessor = currentAssessData.Assessor ?? "Unknown",
+                Verifier = currentAssessData.Verifier ?? "",
+                Verifiers = new SelectList(users),
+                Reviewers = new SelectList(users)
+            };
         }
     }
 }

--- a/src/Portal/Portal/Pages/DbAssessment/_Operators.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_Operators.cshtml.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Newtonsoft.Json;
 using Portal.Models;
+using WorkflowDatabase.EF;
 using WorkflowDatabase.EF.Models;
 
 namespace Portal.Pages.DbAssessment
@@ -25,6 +26,8 @@ namespace Portal.Pages.DbAssessment
         public SelectList Verifiers { get; set; }
 
         public SelectList Reviewers { get; set; }
+
+        public WorkflowStage ParentPage { get; set; }
 
         public void OnGet()
         {

--- a/src/Portal/Portal/Pages/DbAssessment/_Operators.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_Operators.cshtml.cs
@@ -31,7 +31,7 @@ namespace Portal.Pages.DbAssessment
 
         }
 
-        internal static _OperatorsModel GetOperatorsData(DbAssessmentAssessData currentAssessData)
+        internal static _OperatorsModel GetOperatorsData(IOperatorData currentData)
         {
             if (!System.IO.File.Exists(@"Data\Users.json")) throw new FileNotFoundException(@"Data\Users.json");
 
@@ -42,9 +42,9 @@ namespace Portal.Pages.DbAssessment
 
             return new _OperatorsModel
             {
-                Reviewer = currentAssessData.Reviewer ?? "",
-                Assessor = currentAssessData.Assessor ?? "Unknown",
-                Verifier = currentAssessData.Verifier ?? "",
+                Reviewer = currentData.Reviewer ?? "",
+                Assessor = currentData.Assessor ?? "Unknown",
+                Verifier = currentData.Verifier ?? "",
                 Verifiers = new SelectList(users),
                 Reviewers = new SelectList(users)
             };

--- a/src/Portal/Portal/Pages/Index.cshtml
+++ b/src/Portal/Portal/Pages/Index.cshtml
@@ -311,12 +311,12 @@
                         'searchable': false
                     },
                     {
-                        'targets': [12],
+                        'targets': [13],
                         'orderable': false,
                         'searchable': false
                     },
                     {
-                        'targets': [13],
+                        'targets': [14],
                         'visible': false,
                         'searchable': false
                     }
@@ -324,7 +324,7 @@
                 "order": [[2, 'asc']],
                 "scrollX": true,
                 "createdRow": function (row, data, dataIndex) {
-                    if (data[13] === "") {
+                    if (data[14] === "") {
                         $("td.details-control", row).removeClass("details-control");
                         $("td.details-control i", row).removeClass("fa");
                     }
@@ -332,7 +332,7 @@
             });
 
             function format(data) {
-                return '<span class="note-formatting">' + data[13] + '</span>';
+                return '<span class="note-formatting">' + data[14] + '</span>';
             }
 
             $('#inFlightTasks tbody').on('click',

--- a/src/Portal/Portal/Pages/Index.cshtml
+++ b/src/Portal/Portal/Pages/Index.cshtml
@@ -48,6 +48,7 @@
                     <th>Source Name</th>
                     <th>Workspace</th>
                     <th>Stage</th>
+                    <th>Reviewer</th>
                     <th>Assessor</th>
                     <th>Verifier</th>
                     <th>Team</th>
@@ -91,6 +92,7 @@
                         </td>
                         <td></td>
                         <td></td>
+                        <td></td>
                         <td>
                             @task.Team
                         </td>
@@ -131,6 +133,7 @@
                     <th>Source Name</th>
                     <th>Workspace</th>
                     <th>Stage</th>
+                    <th>Reviewer</th>
                     <th>Assessor</th>
                     <th>Verifier</th>
                     <th>Team</th>
@@ -172,6 +175,9 @@
                         </td>
                         <td>
                             @task.TaskStage
+                        </td>
+                        <td>
+                            @task.Reviewer
                         </td>
                         <td>
                             @task.Assessor

--- a/src/Portal/Portal/Pages/Index.cshtml.cs
+++ b/src/Portal/Portal/Pages/Index.cshtml.cs
@@ -196,9 +196,9 @@ namespace Portal.Pages
                     break;
                 case "Verify":
                     throw new NotImplementedException($"'{taskStage}' not implemented");
-                    // TODO: implement Verify Data
-                    //var verify = await _dbContext.DbAssessmentVerifyData.FirstAsync(r => r.ProcessId == processId);
-                    //verify.Verifier = userName;
+                // TODO: implement Verify Data
+                //var verify = await _dbContext.DbAssessmentVerifyData.FirstAsync(r => r.ProcessId == processId);
+                //verify.Verifier = userName;
                 default:
                     throw new NotImplementedException($"'{taskStage}' not implemented");
             }

--- a/src/Portal/Portal/wwwroot/css/site.css
+++ b/src/Portal/Portal/wwwroot/css/site.css
@@ -594,3 +594,5 @@ ol.error-list li::before {
 }
 
 /* End ordered lists */
+
+operator { }

--- a/src/Portal/Portal/wwwroot/js/Assess.js
+++ b/src/Portal/Portal/wwwroot/js/Assess.js
@@ -1,5 +1,7 @@
 ﻿$(document).ready(function () {
 
+    $("#Reviewer").prop("disabled", true);
+
     setAssessDoneHandler();
     setAssessSaveHandler();
 

--- a/src/Portal/Portal/wwwroot/js/Review.js
+++ b/src/Portal/Portal/wwwroot/js/Review.js
@@ -122,11 +122,11 @@
         var promise = users.initialize();
         promise
             .done(function () {
-                $("#Reviewer").prop("disabled", false);
+              //  $("#Reviewer").prop("disabled", false);
                 removeOperatorsInitialiseErrors();
             })
             .fail(function () {
-                $('#Reviewer.typeahead, #Assessor.typeahead, #Verifier.typeahead').prop("disabled", true);
+               // $('#Reviewer.typeahead, #Assessor.typeahead, #Verifier.typeahead').prop("disabled", true);
                 var errorArray = ["Failed to look up users. Try refreshing the page."];
                 displayOperatorsInitialiseErrors(errorArray);
             });

--- a/src/Portal/Portal/wwwroot/js/Review.js
+++ b/src/Portal/Portal/wwwroot/js/Review.js
@@ -1,5 +1,9 @@
 ﻿$(document).ready(function () {
 
+    $('#operators').find('div .operator:gt(0)').hide();
+    
+    initialiseOperatorsTypeaheads();
+    
     setReviewDoneHandler();
     setReviewSaveHandler();
 
@@ -99,5 +103,68 @@
         $("#btnSave").click(function (e) {
             completeReview("Save");
         });
+    }
+
+    function initialiseOperatorsTypeaheads() {
+
+        removeOperatorsInitialiseErrors();
+
+        var users = new Bloodhound({
+            datumTokenizer: Bloodhound.tokenizers.whitespace,
+            queryTokenizer: Bloodhound.tokenizers.whitespace,
+            prefetch: {
+                url: "/Index/?handler=Users",
+                ttl: 60000
+            },
+            initialize: false
+        });
+
+        var promise = users.initialize();
+        promise
+            .done(function () {
+                $("#Reviewer").prop("disabled", false);
+                removeOperatorsInitialiseErrors();
+            })
+            .fail(function () {
+                $('#Reviewer.typeahead, #Assessor.typeahead, #Verifier.typeahead').prop("disabled", true);
+                var errorArray = ["Failed to look up users. Try refreshing the page."];
+                displayOperatorsInitialiseErrors(errorArray);
+            });
+
+        $('#Reviewer.typeahead, #Assessor.typeahead, #Verifier.typeahead').typeahead({
+                hint: true,
+                highlight: true,    /* Enable substring highlighting */
+                minLength: 3        /* Specify minimum characters required for showing result */
+            },
+            {
+                name: 'users',
+                source: users,
+                limit: 100,
+                templates: {
+                    notFound: '<div>No results</div>'
+                }
+            });
+    }
+
+    function displayOperatorsInitialiseErrors(errorStringArray) {
+
+        var orderedList = $("#operatorsErrorList");
+
+        // == to catch undefined and null
+        if (errorStringArray == null) {
+            orderedList.append("<li>An unknown error has occurred</li>");
+
+        } else {
+            errorStringArray.forEach(function (item) {
+                orderedList.append("<li>" + item + "</li>");
+            });
+        }
+
+        $("#operatorsErrorMessages").collapse("show");
+    }
+
+    function removeOperatorsInitialiseErrors() {
+        $("#operatorsErrorMessages").collapse("hide");
+        $("#operatorsErrorList").empty();
     }
 });

--- a/src/Portal/Portal/wwwroot/js/Review.js
+++ b/src/Portal/Portal/wwwroot/js/Review.js
@@ -122,11 +122,9 @@
         var promise = users.initialize();
         promise
             .done(function () {
-              //  $("#Reviewer").prop("disabled", false);
                 removeOperatorsInitialiseErrors();
             })
             .fail(function () {
-               // $('#Reviewer.typeahead, #Assessor.typeahead, #Verifier.typeahead').prop("disabled", true);
                 var errorArray = ["Failed to look up users. Try refreshing the page."];
                 displayOperatorsInitialiseErrors(errorArray);
             });

--- a/src/Portal/Portal/wwwroot/js/Verify.js
+++ b/src/Portal/Portal/wwwroot/js/Verify.js
@@ -1,5 +1,7 @@
 ﻿$(document).ready(function () {
 
+    $("#Reviewer").prop("disabled", true);
+
     setVerifyDoneHandler();
     setVerifySaveHandler();
 


### PR DESCRIPTION
- Switch reviewer in operators panel to a text intput and disable on steps after review
- Add operators panel to review page
- Refactor function for get operators data into the view model as a static
- Fix operators layout columns for new changes
- Hook typeahead into existing handler for users on Index
- Display general error for fetching users on page load, in operators
- Hide the second 2 operators when on review page
- Validate valid user for reviewer present on save / prevent done and save using existing code (does not confirm group on validate)
- Introduce interface IOperatorData in EF models to keep GetOperatorsData method shared
- Saving to Db
- Show reviewer in column on landing page
- Introduce new enum for stage to control server-side rendering per page for operators view and disable reviewer input on verify and assess pages