### PR TITLE
Add NVD dependency checker to WorkflowCoordinator

### DIFF
--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+</suppressions>

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -9,10 +9,6 @@ trigger:
     - src/Databases/WorkflowDatabase.EF/*
     - src/Common*
 
-variables:
-  - name: projectName
-    value: workflowcoordinator
-
 stages:
 - stage: Build
   jobs:
@@ -147,7 +143,7 @@ stages:
 
       - task: CmdLine@2
         inputs:
-          script: 'dependency-check --project "WorkflowCoordinator - $(Build.SourceBranchName)" --scan "$(System.DefaultWorkingDirectory)/publish_output" --out "$(Build.SourcesDirectory)\DCReport"'
+          script: 'dependency-check --project "WorkflowCoordinator - $(Build.SourceBranchName)" --scan "$(System.DefaultWorkingDirectory)/publish_output" --out "$(Build.SourcesDirectory)\DCReport" --suppression $(Build.SourcesDirectory)\NVDSuppressions.xml"'
         displayName: "Run NVD Checker"
 
       - task: PublishPipelineArtifact@1

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -126,6 +126,13 @@ stages:
       #     downloadPath: '$(System.ArtifactsDirectory)' 
 
       - task: UseDotNet@2
+        displayName: 'Use .NET Core 2.2.x SDK'
+        inputs:
+          packageType: sdk
+          version: 2.2.x
+          installationPath: $(Agent.ToolsDirectory)\\dotnet
+
+      - task: UseDotNet@2
         displayName: 'Use .NET Core 3.1.x SDK'
         inputs:
           packageType: sdk

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -118,18 +118,18 @@ stages:
       pool: NautilusBuild
 
       steps:
-      - task: DownloadBuildArtifacts@0
-        displayName: 'Download Build Artifacts'
-        inputs:
-          buildType: 'current'
-          downloadType: 'specific'
-          downloadPath: '$(System.ArtifactsDirectory)' 
+      # - task: DownloadBuildArtifacts@0
+      #   displayName: 'Download Build Artifacts'
+      #   inputs:
+      #     buildType: 'current'
+      #     downloadType: 'specific'
+      #     downloadPath: '$(System.ArtifactsDirectory)' 
 
       - task: DotNetCoreCLI@2
         inputs:
           command: publish
           arguments: "--configuration $(BuildConfiguration) --output $(System.DefaultWorkingDirectory)/publish_output"
-          projects: "**/$(projectName).csproj"
+          projects: "**/workflowcoordinator.csproj"
           publishWebProjects: false
           modifyOutputPath: false
           zipAfterPublish: false

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -113,6 +113,7 @@ stages:
 
     - job: DependencyCheck
       displayName: "Dependency Check"
+      dependsOn: Build
       pool: NautilusBuild
       steps:
         - task: DotNetCoreCLI@2

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -111,7 +111,7 @@ stages:
           publishLocation: 'Container'
         displayName: 'Publish workflowcoordinator Artifact'
 
-- stage: Build
+- stage: DependencyCheck
   dependsOn: Build
   jobs:
     - job: DependencyCheck

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -9,6 +9,10 @@ trigger:
     - src/Databases/WorkflowDatabase.EF/*
     - src/Common*
 
+variables:
+  - name: projectName
+    value: workflowcoordinator
+
 stages:
 - stage: Build
   jobs:
@@ -124,6 +128,13 @@ stages:
       #     buildType: 'current'
       #     downloadType: 'specific'
       #     downloadPath: '$(System.ArtifactsDirectory)' 
+
+      - task: UseDotNet@2
+        displayName: 'Use .NET Core 3.1.x SDK'
+        inputs:
+          packageType: sdk
+          version: 3.1.x
+          installationPath: $(Agent.ToolsDirectory)\\dotnet
 
       - task: DotNetCoreCLI@2
         inputs:

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -111,7 +111,7 @@ stages:
           publishLocation: 'Container'
         displayName: 'Publish workflowcoordinator Artifact'
 
-  - job: DependencyCheck
+    - job: DependencyCheck
       displayName: "Dependency Check"
       pool: NautilusBuild
       steps:

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -111,6 +111,35 @@ stages:
           publishLocation: 'Container'
         displayName: 'Publish workflowcoordinator Artifact'
 
+  - job: DependencyCheck
+      displayName: "Dependency Check"
+      pool: NautilusBuild
+      steps:
+        - task: DotNetCoreCLI@2
+          inputs:
+            command: publish
+            arguments: "--configuration $(BuildConfiguration) --output $(System.DefaultWorkingDirectory)/publish_output"
+            projects: "**/$(projectName).csproj"
+            publishWebProjects: false
+            modifyOutputPath: false
+            zipAfterPublish: false
+        - task: CmdLine@2
+          inputs:
+            script: 'dependency-check --project "WorkflowCoordinator - $(Build.SourceBranchName)" --scan "$(System.DefaultWorkingDirectory)/publish_output" --out "$(Build.SourcesDirectory)\DCReport"'
+          displayName: "Run NVD Checker"
+
+        - task: PublishPipelineArtifact@1
+          inputs:
+            targetPath: '$(Build.SourcesDirectory)\DCReport'
+            artifact: "NVD report"
+            publishLocation: "pipeline"
+
+        - task: PowerShell@2
+          displayName: "Fail build if depdency checker has vulnerabilities"
+          inputs:
+            targetType: inline
+            script: Invoke-VulnerabilityCheck -ReportLocation $(Build.SourcesDirectory)\DCReport\*
+
 - stage: DeployDev
   dependsOn: Build
   jobs:

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -111,35 +111,37 @@ stages:
           publishLocation: 'Container'
         displayName: 'Publish workflowcoordinator Artifact'
 
+- stage: Build
+  dependsOn: Build
+  jobs:
     - job: DependencyCheck
-      displayName: "Dependency Check"
-      dependsOn: Build
       pool: NautilusBuild
+
       steps:
-        - task: DotNetCoreCLI@2
-          inputs:
-            command: publish
-            arguments: "--configuration $(BuildConfiguration) --output $(System.DefaultWorkingDirectory)/publish_output"
-            projects: "**/$(projectName).csproj"
-            publishWebProjects: false
-            modifyOutputPath: false
-            zipAfterPublish: false
-        - task: CmdLine@2
-          inputs:
-            script: 'dependency-check --project "WorkflowCoordinator - $(Build.SourceBranchName)" --scan "$(System.DefaultWorkingDirectory)/publish_output" --out "$(Build.SourcesDirectory)\DCReport"'
-          displayName: "Run NVD Checker"
+      - task: DotNetCoreCLI@2
+        inputs:
+          command: publish
+          arguments: "--configuration $(BuildConfiguration) --output $(System.DefaultWorkingDirectory)/publish_output"
+          projects: "**/$(projectName).csproj"
+          publishWebProjects: false
+          modifyOutputPath: false
+          zipAfterPublish: false
+      - task: CmdLine@2
+        inputs:
+          script: 'dependency-check --project "WorkflowCoordinator - $(Build.SourceBranchName)" --scan "$(System.DefaultWorkingDirectory)/publish_output" --out "$(Build.SourcesDirectory)\DCReport"'
+        displayName: "Run NVD Checker"
 
-        - task: PublishPipelineArtifact@1
-          inputs:
-            targetPath: '$(Build.SourcesDirectory)\DCReport'
-            artifact: "NVD report"
-            publishLocation: "pipeline"
+      - task: PublishPipelineArtifact@1
+        inputs:
+          targetPath: '$(Build.SourcesDirectory)\DCReport'
+          artifact: "NVD report"
+          publishLocation: "pipeline"
 
-        - task: PowerShell@2
-          displayName: "Fail build if depdency checker has vulnerabilities"
-          inputs:
-            targetType: inline
-            script: Invoke-VulnerabilityCheck -ReportLocation $(Build.SourcesDirectory)\DCReport\*
+      - task: PowerShell@2
+        displayName: "Fail build if depdency checker has vulnerabilities"
+        inputs:
+          targetType: inline
+          script: Invoke-VulnerabilityCheck -ReportLocation $(Build.SourcesDirectory)\DCReport\*
 
 - stage: DeployDev
   dependsOn: Build

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -159,7 +159,9 @@ stages:
           script: Invoke-VulnerabilityCheck -ReportLocation $(Build.SourcesDirectory)\DCReport\*
 
 - stage: DeployDev
-  dependsOn: Build
+  dependsOn: 
+    - Build
+    - DependencyCheck
   jobs:
     - deployment: DeployWorkflowCoordinatorDev
       displayName: Deploy Workflowcoordinator NSB Service
@@ -177,7 +179,9 @@ stages:
                   packageForLinux: '$(Pipeline.Workspace)/workflowcoordinator/WebJob'
 
 - stage: DeployUAT
-  dependsOn: Build
+  dependsOn: 
+    - Build
+    - DependencyCheck  
   jobs:
     - deployment: DeployWorkflowCoordinatorUAT
       displayName: Deploy Workflowcoordinator NSB Service
@@ -195,7 +199,9 @@ stages:
                   packageForLinux: '$(Pipeline.Workspace)/workflowcoordinator/WebJob'
 
 - stage: DeployPre
-  dependsOn: Build
+  dependsOn:
+    - Build
+    - DependencyCheck
   jobs:
     - deployment: DeployWorkflowCoordinatorPre
       displayName: Deploy Workflowcoordinator NSB Service

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -118,6 +118,13 @@ stages:
       pool: NautilusBuild
 
       steps:
+      - task: DownloadBuildArtifacts@0
+        displayName: 'Download Build Artifacts'
+        inputs:
+          buildType: 'current'
+          downloadType: 'specific'
+          downloadPath: '$(System.ArtifactsDirectory)' 
+
       - task: DotNetCoreCLI@2
         inputs:
           command: publish
@@ -126,6 +133,7 @@ stages:
           publishWebProjects: false
           modifyOutputPath: false
           zipAfterPublish: false
+
       - task: CmdLine@2
         inputs:
           script: 'dependency-check --project "WorkflowCoordinator - $(Build.SourceBranchName)" --scan "$(System.DefaultWorkingDirectory)/publish_output" --out "$(Build.SourcesDirectory)\DCReport"'

--- a/workflow-coordinator-azure-pipelines.yml
+++ b/workflow-coordinator-azure-pipelines.yml
@@ -118,13 +118,6 @@ stages:
       pool: NautilusBuild
 
       steps:
-      # - task: DownloadBuildArtifacts@0
-      #   displayName: 'Download Build Artifacts'
-      #   inputs:
-      #     buildType: 'current'
-      #     downloadType: 'specific'
-      #     downloadPath: '$(System.ArtifactsDirectory)' 
-
       - task: UseDotNet@2
         displayName: 'Use .NET Core 2.2.x SDK'
         inputs:


### PR DESCRIPTION
- Add stage to WorkflowCoordinator YAML to run dependency checker
- Publish report as an artefact
- Make deploy stages depend on successful build and NVD report passing