### PR TITLE
Features/use basic auth for sdra

### DIFF
--- a/src/DataServices/DataServices/Adapters/AssessmentWebServiceSoapClientAdapter.cs
+++ b/src/DataServices/DataServices/Adapters/AssessmentWebServiceSoapClientAdapter.cs
@@ -26,7 +26,7 @@ namespace DataServices.Adapters
                     MaxReceivedMessageSize = int.MaxValue,
                     Security =
                     {
-                        Mode = BasicHttpSecurityMode.TransportCredentialOnly,
+                        Mode = BasicHttpSecurityMode.Transport,
                         Transport = {ClientCredentialType = HttpClientCredentialType.Basic}
                     }
                 };

--- a/src/DataServices/DataServices/Adapters/DataAccessWebServiceSoapClientAdapter.cs
+++ b/src/DataServices/DataServices/Adapters/DataAccessWebServiceSoapClientAdapter.cs
@@ -26,7 +26,7 @@ namespace DataServices.Adapters
                     MaxReceivedMessageSize = int.MaxValue,
                     Security =
                     {
-                        Mode = BasicHttpSecurityMode.TransportCredentialOnly,
+                        Mode = BasicHttpSecurityMode.Transport,
                         Transport = {ClientCredentialType = HttpClientCredentialType.Basic}
                     }
                 };

--- a/src/DataServices/DataServices/Config/SecretsConfig.cs
+++ b/src/DataServices/DataServices/Config/SecretsConfig.cs
@@ -1,0 +1,8 @@
+﻿namespace DataServices.Config
+{
+    public class SecretsConfig
+    {
+        public string SdraWebserviceUsername { get; set; }
+        public string SdraWebservicePassword { get; set; }
+    }
+}

--- a/src/DataServices/DataServices/Startup.cs
+++ b/src/DataServices/DataServices/Startup.cs
@@ -36,6 +36,8 @@ namespace DataServices
             Configuration.GetSection("SdraDbSection").Bind(startupSecrets);
             Configuration.GetSection("LoggingDbSection").Bind(startupSecrets);
 
+            services.AddOptions<SecretsConfig>().Bind(Configuration.GetSection("SdraWebservice"));
+
             LoggingHelper.SetupLogging(isLocalDb, startupLoggingConfig, startupSecrets);
 
             var connection = Common.Helpers.DatabasesHelpers.BuildOracleConnectionString(startupSecrets.DataSource,


### PR DESCRIPTION
- Use Basic authentication over HTTPS when performing operations against the SDRA Assessment or DataAccess webservices
- Retrieve credentials from AKV for relevant account