### PR TITLE
Removed the API tests from the pipeline

### DIFF
--- a/data-services-azure-pipelines.yml
+++ b/data-services-azure-pipelines.yml
@@ -159,13 +159,6 @@ stages:
                   azureSubscription: 'TaskmanagerDev'
                   WebAppName: 'TaskManager-Dev-api-Dataservice'
                   packageForLinux: '$(Pipeline.Workspace)/dataservices/dataservices'
-              - task: Maven@3
-                displayName: 'Run Data Services API Tests'
-                inputs:
-                  mavenPomFile: '$(Pipeline.Workspace)/dataservices.apitests/pom.xml'
-                  goals: test
-                  testResultsFiles: '$(Pipeline.Workspace)/dataservices.apitests/target/surefire-reports/TEST-*.xml'
-                  testRunTitle: 'Data Services API Tests'
 
 - stage: DeployUAT
   dependsOn: 
@@ -186,13 +179,6 @@ stages:
                   azureSubscription: 'TaskmanagerUAT-SC'
                   WebAppName: 'TaskManager-UAT-api-Dataservice'
                   packageForLinux: '$(Pipeline.Workspace)/dataservices/dataservices'
-              - task: Maven@3
-                displayName: 'Run Data Services API Tests'
-                inputs:
-                  mavenPomFile: '$(Pipeline.Workspace)/dataservices.apitests/pom.xml'
-                  goals: test
-                  testResultsFiles: '$(Pipeline.Workspace)/dataservices.apitests/target/surefire-reports/TEST-*.xml'
-                  testRunTitle: 'Data Services API Tests'
 
 - stage: DeployPre
   dependsOn: 
@@ -213,10 +199,3 @@ stages:
                   azureSubscription: 'TaskmanagerPre-SC'
                   WebAppName: 'TaskManager-Pre-api-Dataservice'
                   packageForLinux: '$(Pipeline.Workspace)/dataservices/dataservices'
-              - task: Maven@3
-                displayName: 'Run Data Services API Tests'
-                inputs:
-                  mavenPomFile: '$(Pipeline.Workspace)/dataservices.apitests/pom.xml'
-                  goals: test
-                  testResultsFiles: '$(Pipeline.Workspace)/dataservices.apitests/target/surefire-reports/TEST-*.xml'
-                  testRunTitle: 'Data Services API Tests'


### PR DESCRIPTION
The Data Services API tests are inadequate and as set up in the pipeline would only run against a single environment (despite claiming to run against each of Dev, UAT and Pre). This was not clear from looking at the pipeline and leads to false confidence.
As this area is not under active development and the tests are currently breaking the pipeline (due to a missing environment variable), this PR is to remove them from the pipeline.