### PR TITLE
Switch over to the AAD SQL account

### DIFF
--- a/workflow-database-azure-pipelines.yml
+++ b/workflow-database-azure-pipelines.yml
@@ -48,12 +48,12 @@ stages:
             steps:
               - task: SqlAzureDacpacDeployment@1
                 inputs:
-                  # azureSubscription: 'TM2 Dev/Test Sub Dev RG'
+                  AuthenticationType: aadAuthenticationPassword
                   azureSubscription: 'SharedServicesPre'
                   ServerName: '$(ServerNameDev)'
                   DatabaseName: '$(DatabaseNameDev)'
-                  SqlUsername: '$(SQLUsernameDev)'
-                  SqlPassword: '$(SQLPasswordDev)'
+                  aadSqlUsername: '$(SQLUsernameDev)'
+                  aadSqlPassword: '$(SQLPasswordDev)'
                   DacpacFile: '$(Pipeline.Workspace)/workflowdatabase/WorkflowDatabase.dacpac'
 
 - stage: DeployUAT
@@ -69,12 +69,12 @@ stages:
             steps:
               - task: SqlAzureDacpacDeployment@1
                 inputs:
-                  # azureSubscription: 'TM2 Dev/Test Sub Dev RG'
+                  AuthenticationType: aadAuthenticationPassword
                   azureSubscription: 'SharedServicesPre'
                   ServerName: '$(ServerNameUAT)'
                   DatabaseName: '$(DatabaseNameUAT)'
-                  SqlUsername: '$(SQLUsernameUAT)'
-                  SqlPassword: '$(SQLPasswordUAT)'
+                  aadSqlUsername: '$(SQLUsernameUAT)'
+                  aadSqlPassword: '$(SQLPasswordUAT)'
                   DacpacFile: '$(Pipeline.Workspace)/workflowdatabase/WorkflowDatabase.dacpac'
 
 - stage: DeployPre
@@ -90,10 +90,10 @@ stages:
             steps:
               - task: SqlAzureDacpacDeployment@1
                 inputs:
-                  # azureSubscription: 'TM2 Dev/Test Sub Dev RG'
+                  AuthenticationType: aadAuthenticationPassword
                   azureSubscription: 'SharedServicesPre'
                   ServerName: '$(ServerNamePre)'
                   DatabaseName: '$(DatabaseNamePre)'
-                  SqlUsername: '$(SQLUsernamePre)'
-                  SqlPassword: '$(SQLPasswordPre)'
+                  aadSqlUsername: '$(SQLUsernamePre)'
+                  aadSqlPassword: '$(SQLPasswordPre)'
                   DacpacFile: '$(Pipeline.Workspace)/workflowdatabase/WorkflowDatabase.dacpac'


### PR DESCRIPTION
We now Terraform the databases and users with an AAD account so that Azure apps can be added. Switching DACPAC deployments over to it too.

I've changed the pipeline variables and tested all 3 environments.

