### PR TITLE
Features/ncne third party support dates

### DIFF
--- a/src/NCNEPortal.UnitTests/WorkflowTests.cs
+++ b/src/NCNEPortal.UnitTests/WorkflowTests.cs
@@ -145,6 +145,103 @@ namespace NCNEPortal.UnitTests
 
 
         }
+
+        [Test]
+        public async Task Test_3ps_Expected_date_without_sent_to_date()
+        {
+            _workflowModel.ProcessId = 123;
+            _workflowModel.RepromatDate = DateTime.Now;
+            _workflowModel.ChartType = "Primary";
+            _workflowModel.PublicationDate = DateTime.Now;
+            _workflowModel.Compiler = "Stuart";
+            _workflowModel.Dating = 1;
+            _workflowModel.SentTo3Ps = true;
+            _workflowModel.SendDate3ps = null;
+            _workflowModel.ExpectedReturnDate3ps = DateTime.Now;
+
+            await _workflowModel.OnPostSaveAsync(_workflowModel.ProcessId, _workflowModel.ChartType);
+
+            Assert.GreaterOrEqual(_workflowModel.ValidationErrorMessages.Count, 1);
+            Assert.IsTrue(_workflowModel.ValidationErrorMessages.Contains("3PS : Please enter date sent to 3PS before entering expected return date"));
+        }
+
+
+        [Test]
+        public async Task Test_3ps_Actual_return_date_without_sent_to_date()
+        {
+            _workflowModel.ProcessId = 123;
+            _workflowModel.RepromatDate = DateTime.Now;
+            _workflowModel.ChartType = "Primary";
+            _workflowModel.PublicationDate = DateTime.Now;
+            _workflowModel.Compiler = "Stuart";
+            _workflowModel.Dating = 1;
+            _workflowModel.SentTo3Ps = true;
+            _workflowModel.SendDate3ps = null;
+            _workflowModel.ActualReturnDate3ps = DateTime.Now;
+
+            await _workflowModel.OnPostSaveAsync(_workflowModel.ProcessId, _workflowModel.ChartType);
+
+            Assert.GreaterOrEqual(_workflowModel.ValidationErrorMessages.Count, 1);
+            Assert.IsTrue(_workflowModel.ValidationErrorMessages.Contains("3PS : Please enter date sent to 3PS before entering actual return date"));
+        }
+        [Test]
+        public async Task Test_3ps_Expected_return_date_earlier_than_sent_to_date()
+        {
+            _workflowModel.ProcessId = 123;
+            _workflowModel.RepromatDate = DateTime.Now;
+            _workflowModel.ChartType = "Primary";
+            _workflowModel.PublicationDate = DateTime.Now;
+            _workflowModel.Compiler = "Stuart";
+            _workflowModel.Dating = 1;
+            _workflowModel.SentTo3Ps = true;
+            _workflowModel.SendDate3ps = DateTime.Now;
+            _workflowModel.ExpectedReturnDate3ps = DateTime.Now.AddDays(-2);
+
+            await _workflowModel.OnPostSaveAsync(_workflowModel.ProcessId, _workflowModel.ChartType);
+
+            Assert.GreaterOrEqual(_workflowModel.ValidationErrorMessages.Count, 1);
+            Assert.IsTrue(_workflowModel.ValidationErrorMessages.Contains("3PS : Expected return date cannot be earlier than Sent to 3PS date"));
+        }
+
+        [Test]
+        public async Task Test_3ps_Actual_return_date_earlier_than_sent_to_date()
+        {
+            _workflowModel.ProcessId = 123;
+            _workflowModel.RepromatDate = DateTime.Now;
+            _workflowModel.ChartType = "Primary";
+            _workflowModel.PublicationDate = DateTime.Now;
+            _workflowModel.Compiler = "Stuart";
+            _workflowModel.Dating = 1;
+            _workflowModel.SentTo3Ps = true;
+            _workflowModel.SendDate3ps = DateTime.Now;
+            _workflowModel.ActualReturnDate3ps = DateTime.Now.AddDays(-2);
+
+            await _workflowModel.OnPostSaveAsync(_workflowModel.ProcessId, _workflowModel.ChartType);
+
+            Assert.GreaterOrEqual(_workflowModel.ValidationErrorMessages.Count, 1);
+            Assert.IsTrue(_workflowModel.ValidationErrorMessages.Contains("3PS : Actual return date cannot be earlier than Sent to 3PS date"));
+        }
+
+        [Test]
+        public async Task Test_3ps_Entering_Actual_return_date_without_expected_return_date()
+        {
+            _workflowModel.ProcessId = 123;
+            _workflowModel.RepromatDate = DateTime.Now;
+            _workflowModel.ChartType = "Primary";
+            _workflowModel.PublicationDate = DateTime.Now;
+            _workflowModel.Compiler = "Stuart";
+            _workflowModel.Dating = 1;
+            _workflowModel.SentTo3Ps = true;
+            _workflowModel.SendDate3ps = DateTime.Now;
+            _workflowModel.ActualReturnDate3ps = DateTime.Now;
+            _workflowModel.ExpectedReturnDate3ps = null;
+
+            await _workflowModel.OnPostSaveAsync(_workflowModel.ProcessId, _workflowModel.ChartType);
+
+            Assert.GreaterOrEqual(_workflowModel.ValidationErrorMessages.Count, 1);
+            Assert.IsTrue(_workflowModel.ValidationErrorMessages.Contains("3PS : Please enter expected return date before entering actual return date"));
+        }
+
     }
 
 }

--- a/src/NCNEPortal/Helpers/IPageValidationHelper.cs
+++ b/src/NCNEPortal/Helpers/IPageValidationHelper.cs
@@ -8,11 +8,13 @@ namespace NCNEPortal.Helpers
     public interface IPageValidationHelper
     {
         bool ValidateWorkflowPage(TaskRole taskRole,
-                                        DateTime? publicationDate,
-                                        DateTime? repromatDate,
-                                        int dating,
-                                        String chartType,
-                                        List<String> validationErrorMessages);
+            DateTime? publicationDate,
+            DateTime? repromatDate,
+            int dating,
+            string chartType,
+            (bool SentTo3Ps, DateTime? SendDate3ps, DateTime? ExpectedReturnDate3ps, DateTime? ActualReturnDate3ps)
+                threePsInfo,
+            List<string> validationErrorMessages);
 
 
     }

--- a/src/NCNEPortal/Helpers/PageValidationHelper.cs
+++ b/src/NCNEPortal/Helpers/PageValidationHelper.cs
@@ -60,6 +60,12 @@ namespace NCNEPortal.Helpers
                 isValid = false;
             }
 
+            if ((expectedReturnDate3Ps == null) && (actualReturnDate3Ps != null))
+            {
+                validationErrorMessages.Add("3PS : Please enter expected return date before entering actual return date");
+                isValid = false;
+            }
+
             if (sendDate3Ps != null)
             {
                 if ((expectedReturnDate3Ps != null) && (expectedReturnDate3Ps < sendDate3Ps))

--- a/src/NCNEPortal/Helpers/PageValidationHelper.cs
+++ b/src/NCNEPortal/Helpers/PageValidationHelper.cs
@@ -54,19 +54,26 @@ namespace NCNEPortal.Helpers
         {
             bool isValid = true;
 
-            if ((sendDate3Ps == null) && (expectedReturnDate3Ps != null || actualReturnDate3Ps != null))
+            if (sendDate3Ps == null)
             {
-                validationErrorMessages.Add("3PS : Please enter date sent to 3PS before entering actual and expected return dates");
-                isValid = false;
+                if (expectedReturnDate3Ps != null)
+                {
+                    validationErrorMessages.Add(
+                        "3PS : Please enter date sent to 3PS before entering expected return date");
+                    isValid = false;
+                }
+
+                if (actualReturnDate3Ps != null)
+                {
+                    validationErrorMessages.Add(
+                        "3PS : Please enter date sent to 3PS before entering actual return date");
+                    isValid = false;
+
+                }
             }
 
-            if ((expectedReturnDate3Ps == null) && (actualReturnDate3Ps != null))
-            {
-                validationErrorMessages.Add("3PS : Please enter expected return date before entering actual return date");
-                isValid = false;
-            }
+            else
 
-            if (sendDate3Ps != null)
             {
                 if ((expectedReturnDate3Ps != null) && (expectedReturnDate3Ps < sendDate3Ps))
                 {
@@ -81,6 +88,11 @@ namespace NCNEPortal.Helpers
                 }
             }
 
+            if ((expectedReturnDate3Ps == null) && (actualReturnDate3Ps != null))
+            {
+                validationErrorMessages.Add("3PS : Please enter expected return date before entering actual return date");
+                isValid = false;
+            }
 
             return isValid;
         }

--- a/src/NCNEPortal/Helpers/PageValidationHelper.cs
+++ b/src/NCNEPortal/Helpers/PageValidationHelper.cs
@@ -26,7 +26,9 @@ namespace NCNEPortal.Helpers
 
         public bool ValidateWorkflowPage(TaskRole taskRole, DateTime? publicationDate, DateTime? repromatDate,
             int dating,
-            string chartType, List<string> validationErrorMessages)
+            string chartType,
+            (bool SentTo3Ps, DateTime? SendDate3ps, DateTime? ExpectedReturnDate3ps, DateTime? ActualReturnDate3ps)
+                threePsInfo, List<string> validationErrorMessages)
         {
             bool isValid = ValidateUserRoles(taskRole, validationErrorMessages);
 
@@ -35,10 +37,46 @@ namespace NCNEPortal.Helpers
                 isValid = false;
             }
 
-
+            if (threePsInfo.SentTo3Ps == true)
+            {
+                if (!ValidateThreePs(threePsInfo.SendDate3ps, threePsInfo.ExpectedReturnDate3ps,
+                    threePsInfo.ActualReturnDate3ps, validationErrorMessages))
+                {
+                    isValid = false;
+                }
+            }
 
             return isValid;
 
+        }
+
+        private bool ValidateThreePs(DateTime? sendDate3Ps, DateTime? expectedReturnDate3Ps, DateTime? actualReturnDate3Ps, List<string> validationErrorMessages)
+        {
+            bool isValid = true;
+
+            if ((sendDate3Ps == null) && (expectedReturnDate3Ps != null || actualReturnDate3Ps != null))
+            {
+                validationErrorMessages.Add("3PS : Please enter date sent to 3PS before entering actual and expected return dates");
+                isValid = false;
+            }
+
+            if (sendDate3Ps != null)
+            {
+                if ((expectedReturnDate3Ps != null) && (expectedReturnDate3Ps < sendDate3Ps))
+                {
+                    validationErrorMessages.Add(("3PS : Expected return date cannot be earlier than Sent to 3PS date"));
+                    isValid = false;
+                }
+
+                if ((actualReturnDate3Ps != null) && (actualReturnDate3Ps < sendDate3Ps))
+                {
+                    validationErrorMessages.Add(("3PS : Actual return date cannot be earlier than Sent to 3PS date"));
+                    isValid = false;
+                }
+            }
+
+
+            return isValid;
         }
 
         private bool ValidateDates(DateTime? publicationDate, DateTime? repromatDate, int dating, string chartType, List<string> validationErrorMessages)

--- a/src/NCNEPortal/Pages/Workflow.cshtml
+++ b/src/NCNEPortal/Pages/Workflow.cshtml
@@ -570,12 +570,14 @@
                     </div>
                 </div>
                 <hr class="mt-2 mb-4" />
-                <h4>3PS</h4>
+                <div class="row" align="center">
+                    <h4>3PS</h4>
 
-                <label class="switch ml-2 mb-auto">
-                    <input type="checkbox" id="3psToggle" name="SentTo3Ps" class="success" @(Model.SentTo3Ps ? "checked" : "") value="true">
-                    <span class="slider"></span>
-                </label>
+                    <label class="switch ml-2 mb-auto">
+                        <input type="checkbox" id="3psToggle" name="SentTo3Ps" class="success" @(Model.SentTo3Ps ? "checked" : "") value="true">
+                        <span class="slider"></span>
+                    </label>
+                </div>
                 <div class="row">
                     <div class="col-3">
                         <div class="form-group">

--- a/src/NCNEPortal/Pages/Workflow.cshtml
+++ b/src/NCNEPortal/Pages/Workflow.cshtml
@@ -571,23 +571,28 @@
                 </div>
                 <hr class="mt-2 mb-4" />
                 <h4>3PS</h4>
+
+                <label class="switch ml-2 mb-auto">
+                    <input type="checkbox" id="3psToggle" name="SentTo3Ps" class="success" @(Model.SentTo3Ps ? "checked" : "") value="true">
+                    <span class="slider"></span>
+                </label>
                 <div class="row">
                     <div class="col-3">
                         <div class="form-group">
-                            <div>@Html.LabelFor(model => model.SendDate3ps)</div>
-                            <div>@Html.DisplayFor(model => model.SendDate3ps)</div>
+                            <div>@Html.LabelFor(model => model.SendDate3ps, new { @class = "col-form-label" })</div>
+                            <div>@Html.TextBoxFor(model => model.SendDate3ps, "{0:dd/MM/yyyy}", new { @class = "form-control form-text-input" })</div>
                         </div>
                     </div>
                     <div class="col-3">
                         <div class="form-group">
-                            <div>@Html.LabelFor(model => model.ExpectedReturnDate3ps)</div>
-                            <div>@Html.DisplayFor(model => model.ExpectedReturnDate3ps)</div>
+                            <div>@Html.LabelFor(model => model.ExpectedReturnDate3ps, new { @class = "col-form-label" })</div>
+                            <div>@Html.TextBoxFor(model => model.ExpectedReturnDate3ps, "{0:dd/MM/yyyy}", new { @class = "form-control form-text-input" })</div>
                         </div>
                     </div>
                     <div class="col-3">
                         <div class="form-group">
-                            <div>@Html.LabelFor(model => model.ActualReturnDate3ps)</div>
-                            <div>@Html.DisplayFor(model => model.ActualReturnDate3ps)</div>
+                            <div>@Html.LabelFor(model => model.ActualReturnDate3ps, new { @class = "col-form-label" })</div>
+                            <div>@Html.TextBoxFor(model => model.ActualReturnDate3ps, "{0:dd/MM/yyyy}", new { @class = "form-control form-text-input" })</div>
                         </div>
                     </div>
                 </div>

--- a/src/NCNEPortal/wwwroot/js/Workflow.js
+++ b/src/NCNEPortal/wwwroot/js/Workflow.js
@@ -72,25 +72,17 @@
          $("#lblRepDate").hide();
      }
 
-
-    var sentto3ps = $("#3psToggle").prop("checked");
-    if (sentto3ps==true)
-        $("#3psToggle").prop("disabled", true);
-    set3psStatus(sentto3ps);
+    set3psStatus();
 
     $("#3psToggle").on("change",
         function() {
-            var sentto3ps = $("#3psToggle").prop("checked");
-            set3psStatus(sentto3ps);
-         
-            
+            set3psStatus();
         });
 
 
-    
+    function set3psStatus() {
 
-    function set3psStatus(sentto3ps) {
-    
+        var sentto3ps = $("#3psToggle").prop("checked");
 
         if (sentto3ps) {
             $("#SendDate3ps").prop("disabled", false);
@@ -99,9 +91,15 @@
             
         }
         else {
+
+            $("#SendDate3ps").val("").datepicker("update");
+            $("#ExpectedReturnDate3ps").val("").datepicker("update");
+            $("#ActualReturnDate3ps").val("").datepicker("update");
+            
             $("#SendDate3ps").prop("disabled", true);
             $("#ExpectedReturnDate3ps").prop("disabled", true);
             $("#ActualReturnDate3ps").prop("disabled", true);
+
         }
 
     }

--- a/src/NCNEPortal/wwwroot/js/Workflow.js
+++ b/src/NCNEPortal/wwwroot/js/Workflow.js
@@ -9,8 +9,7 @@
             return "Changes detected";
         }
     };
-
-
+    
     $("#RepromatDate").datepicker({
         autoclose: true,
         todayHighLight: true,
@@ -41,6 +40,26 @@
         format: 'dd/mm/yyyy'
     }).datepicker('update');
 
+    $("#SendDate3ps").datepicker({
+        autoclose: true,
+        todayHighLight: true,
+        format: 'dd/mm/yyyy'
+    }).datepicker('update');
+
+    $("#ExpectedReturnDate3ps").datepicker({
+        autoclose: true,
+        todayHighLight: true,
+        format: 'dd/mm/yyyy'
+    }).datepicker('update');
+
+    $("#ActualReturnDate3ps").datepicker({
+        autoclose: true,
+        todayHighLight: true,
+        format: 'dd/mm/yyyy'
+    }).datepicker('update');
+
+
+
 
     var chartType = $("#chartType").text();
     if (chartType.trim() === "Adoption") {
@@ -54,6 +73,34 @@
      }
 
 
+    set3psStatus();
+
+    $("#3psToggle").on("change",
+        function() {
+
+            set3psStatus();
+         
+            
+        });
+
+
+    
+
+    function set3psStatus() {
+        var sentto3ps = $("#3psToggle").prop("checked");
+
+        if (sentto3ps) {
+            $("#SendDate3ps").prop("disabled", false);
+            $("#ExpectedReturnDate3ps").prop("disabled", false);
+            $("#ActualReturnDate3ps").prop("disabled", false);
+        }
+        else {
+            $("#SendDate3ps").prop("disabled", true);
+            $("#ExpectedReturnDate3ps").prop("disabled", true);
+            $("#ActualReturnDate3ps").prop("disabled", true);
+        }
+
+    }
 
 
     $("#Dating").change(function() {

--- a/src/NCNEPortal/wwwroot/js/Workflow.js
+++ b/src/NCNEPortal/wwwroot/js/Workflow.js
@@ -73,12 +73,15 @@
      }
 
 
-    set3psStatus();
+    var sentto3ps = $("#3psToggle").prop("checked");
+    if (sentto3ps==true)
+        $("#3psToggle").prop("disabled", true);
+    set3psStatus(sentto3ps);
 
     $("#3psToggle").on("change",
         function() {
-
-            set3psStatus();
+            var sentto3ps = $("#3psToggle").prop("checked");
+            set3psStatus(sentto3ps);
          
             
         });
@@ -86,13 +89,14 @@
 
     
 
-    function set3psStatus() {
-        var sentto3ps = $("#3psToggle").prop("checked");
+    function set3psStatus(sentto3ps) {
+    
 
         if (sentto3ps) {
             $("#SendDate3ps").prop("disabled", false);
             $("#ExpectedReturnDate3ps").prop("disabled", false);
             $("#ActualReturnDate3ps").prop("disabled", false);
+            
         }
         else {
             $("#SendDate3ps").prop("disabled", true);


### PR DESCRIPTION
1. when 3PS is enabled ( using the slider), user can enter sent to 3ps, expected date and actual date. they will be validate before saving
2 When 3PS is disabled (using the slider), all the dates entered before will be removed and the date fields will be disabled. On saving, 3 PS will be set to false in the task information and all the 3ps dates set to Null.