### PR TITLE
Validate current user is the assigned Verifier at sign off

### DIFF
--- a/src/Portal/Portal.UnitTests/VerifyTests.cs
+++ b/src/Portal/Portal.UnitTests/VerifyTests.cs
@@ -215,7 +215,7 @@ namespace Portal.UnitTests
                 .Returns(true);
 
             _hpDbContext.CarisProducts.Add(new CarisProduct()
-                {ProductName = "GB1234", ProductStatus = "Active", TypeKey = "ENC"});
+            { ProductName = "GB1234", ProductStatus = "Active", TypeKey = "ENC" });
             await _hpDbContext.SaveChangesAsync();
 
             _verifyModel.Ion = "Ion";
@@ -245,7 +245,7 @@ namespace Portal.UnitTests
                 .Returns(true);
 
             _hpDbContext.CarisProducts.Add(new CarisProduct()
-                { ProductName = "GB1234", ProductStatus = "Active", TypeKey = "ENC" });
+            { ProductName = "GB1234", ProductStatus = "Active", TypeKey = "ENC" });
             await _hpDbContext.SaveChangesAsync();
 
             _verifyModel.Ion = "Ion";
@@ -271,13 +271,15 @@ namespace Portal.UnitTests
         [Test]
         public async Task Test_OnPostDoneAsync_given_action_done_and_unverified_productactions_then_validation_error_message_is_present()
         {
+            A.CallTo(() => _fakeUserIdentityService.GetFullNameForUser(A<ClaimsPrincipal>.Ignored))
+                .Returns(Task.FromResult("TestUser"));
             A.CallTo(() => _fakeUserIdentityService.ValidateUser(A<string>.Ignored))
                 .Returns(true);
 
             _hpDbContext.CarisProducts.Add(new CarisProduct
-                { ProductName = "GB1234", ProductStatus = "Active", TypeKey = "ENC" });
+            { ProductName = "GB1234", ProductStatus = "Active", TypeKey = "ENC" });
             _hpDbContext.CarisProducts.Add(new CarisProduct
-                { ProductName = "GB1235", ProductStatus = "Active", TypeKey = "ENC" });
+            { ProductName = "GB1235", ProductStatus = "Active", TypeKey = "ENC" });
             await _hpDbContext.SaveChangesAsync();
 
             _verifyModel.Ion = "Ion";
@@ -303,6 +305,8 @@ namespace Portal.UnitTests
         [Test]
         public async Task Test_OnPostDoneAsync_given_action_done_and_unverified_dataimpacts_then_validation_error_message_is_present()
         {
+            A.CallTo(() => _fakeUserIdentityService.GetFullNameForUser(A<ClaimsPrincipal>.Ignored))
+                .Returns(Task.FromResult("TestUser"));
             A.CallTo(() => _fakeUserIdentityService.ValidateUser(A<string>.Ignored))
                 .Returns(true);
 
@@ -359,7 +363,7 @@ namespace Portal.UnitTests
         public async Task Test_OnPostDoneAsync_given_action_done_and_has_active_child_tasks_returns_warning_message()
         {
             A.CallTo(() => _fakeUserIdentityService.GetFullNameForUser(A<ClaimsPrincipal>.Ignored))
-                .Returns(Task.FromResult("This User"));
+                .Returns(Task.FromResult("TestUser"));
             A.CallTo(() => _fakeUserIdentityService.ValidateUser(A<string>.Ignored))
                 .Returns(true);
 
@@ -386,16 +390,7 @@ namespace Portal.UnitTests
 
             });
 
-            _dbContext.AssessmentData.Add(new AssessmentData()
-            {
-                AssessmentDataId = 1,
-                ProcessId = ProcessId
-            });
-
-
             await _dbContext.SaveChangesAsync();
-
-            
 
             await _verifyModel.OnPostDoneAsync(ProcessId, "Done");
 
@@ -408,7 +403,7 @@ namespace Portal.UnitTests
         {
             A.CallTo(() => _fakeUserIdentityService.ValidateUser(A<string>.Ignored))
                 .Returns(true);
-            
+
             _verifyModel.Ion = "Ion";
             _verifyModel.ActivityCode = "ActivityCode";
             _verifyModel.SourceCategory = "SourceCategory";
@@ -460,14 +455,15 @@ namespace Portal.UnitTests
             // Assert
             A.CallTo(() => _pageValidationHelper.ValidateVerifyPage(
                                                                                 A<string>.Ignored,
-                                                                                A<string>.Ignored, 
-                                                                                A<string>.Ignored, 
+                                                                                A<string>.Ignored,
+                                                                                A<string>.Ignored,
                                                                                 A<string>.Ignored,
                                                                                 A<string>.Ignored,
                                                                                 A<List<ProductAction>>.Ignored,
                                                                                 A<List<DataImpact>>.Ignored,
                                                                                 A<string>.Ignored,
                                                                                 A<List<string>>.Ignored,
+                                                                                A<string>.Ignored,
                                                                                 A<string>.Ignored))
                                                             .MustNotHaveHappened();
 
@@ -509,7 +505,7 @@ namespace Portal.UnitTests
             A.CallTo(() => _fakePageValidationHelper.ValidateVerifyPage(A<string>.Ignored, A<string>.Ignored, A<string>.Ignored, A<string>.Ignored,
                     A<string>.Ignored,
                      A<List<ProductAction>>.Ignored, A<List<DataImpact>>.Ignored,
-                     A<string>.Ignored, A<List<string>>.Ignored, A<string>.Ignored))
+                     A<string>.Ignored, A<List<string>>.Ignored, A<string>.Ignored, A<string>.Ignored))
                 .Returns(true);
 
             await _verifyModel.OnPostDoneAsync(ProcessId, "Save");
@@ -546,7 +542,7 @@ namespace Portal.UnitTests
                 A<string>.Ignored, A<string>.Ignored,
                 A<string>.Ignored,
                 A<List<ProductAction>>.Ignored, A<List<DataImpact>>.Ignored,
-                A<string>.Ignored, A<List<string>>.Ignored, A<string>.Ignored))
+                A<string>.Ignored, A<List<string>>.Ignored, A<string>.Ignored, A<string>.Ignored))
                 .Returns(Task.FromResult(true));
 
             await _dbContext.OnHold.AddAsync(new OnHold
@@ -592,7 +588,7 @@ namespace Portal.UnitTests
                     A<string>.Ignored, A<string>.Ignored,
                     A<string>.Ignored,
                     A<List<ProductAction>>.Ignored, A<List<DataImpact>>.Ignored,
-                    A<string>.Ignored, A<List<string>>.Ignored, A<string>.Ignored))
+                    A<string>.Ignored, A<List<string>>.Ignored, A<string>.Ignored, A<string>.Ignored))
                 .Returns(Task.FromResult(true));
 
             await _verifyModel.OnPostDoneAsync(ProcessId, "Save");
@@ -629,7 +625,7 @@ namespace Portal.UnitTests
                     A<string>.Ignored, A<string>.Ignored,
                     A<string>.Ignored,
                     A<List<ProductAction>>.Ignored, A<List<DataImpact>>.Ignored,
-                    A<string>.Ignored, A<List<string>>.Ignored, A<string>.Ignored))
+                    A<string>.Ignored, A<List<string>>.Ignored, A<string>.Ignored, A<string>.Ignored))
                 .Returns(Task.FromResult(true));
 
             _dbContext.OnHold.Add(new OnHold()
@@ -677,6 +673,20 @@ namespace Portal.UnitTests
                 .Returns(true);
 
             await _verifyModel.OnPostRejectVerifyAsync(ProcessId, "Reject");
+
+            Assert.GreaterOrEqual(_verifyModel.ValidationErrorMessages.Count, 1);
+            Assert.Contains("Operators: TestUser is assigned to this task. Please assign the task to yourself and click Save", _verifyModel.ValidationErrorMessages);
+        }
+
+        [Test]
+        public async Task Test_That_Task_With_Verifier_Fails_Validation_If_CurrentUser_Not_Assigned_At_Done()
+        {
+            A.CallTo(() => _fakeUserIdentityService.GetFullNameForUser(A<ClaimsPrincipal>.Ignored))
+                .Returns(Task.FromResult("TestUser2"));
+            A.CallTo(() => _fakeWorkflowServiceApiClient.ProgressWorkflowInstance(123, "123_sn", "Assess", "Verify"))
+                .Returns(true);
+
+            await _verifyModel.OnPostRejectVerifyAsync(ProcessId, "Done");
 
             Assert.GreaterOrEqual(_verifyModel.ValidationErrorMessages.Count, 1);
             Assert.Contains("Operators: TestUser is assigned to this task. Please assign the task to yourself and click Save", _verifyModel.ValidationErrorMessages);

--- a/src/Portal/Portal/Helpers/IPageValidationHelper.cs.cs
+++ b/src/Portal/Portal/Helpers/IPageValidationHelper.cs.cs
@@ -61,23 +61,26 @@ namespace Portal.Helpers
         /// <param name="ion"></param>
         /// <param name="activityCode"></param>
         /// <param name="sourceCategory"></param>
-        /// <param name="currentAssignedVerifier"></param>
+        /// <param name="currentUsername"></param>
         /// <param name="recordProductAction"></param>
         /// <param name="dataImpacts"></param>
         /// <param name="action"></param>
         /// <param name="validationErrorMessages"></param>
         /// <param name="team"></param>
+        /// <param name="formDataAssignedVerifier"></param>
+        /// <param name="currentAssignedVerifier"></param>
         /// <returns></returns>
         Task<bool> ValidateVerifyPage(string ion,
             string activityCode,
             string sourceCategory,
-            string currentAssignedVerifier,
+            string formDataAssignedVerifier,
             string currentUsername,
             List<ProductAction> recordProductAction,
             List<DataImpact> dataImpacts,
             string action,
             List<string> validationErrorMessages,
-            string team);
+            string team,
+            string currentAssignedVerifier = "");
 
 
     }

--- a/src/Portal/Portal/Helpers/IPageValidationHelper.cs.cs
+++ b/src/Portal/Portal/Helpers/IPageValidationHelper.cs.cs
@@ -68,7 +68,7 @@ namespace Portal.Helpers
         /// <param name="validationErrorMessages"></param>
         /// <param name="team"></param>
         /// <param name="formDataAssignedVerifier"></param>
-        /// <param name="currentAssignedVerifier"></param>
+        /// <param name="currentVerifier"></param>
         /// <returns></returns>
         Task<bool> ValidateVerifyPage(string ion,
             string activityCode,
@@ -80,7 +80,7 @@ namespace Portal.Helpers
             string action,
             List<string> validationErrorMessages,
             string team,
-            string currentAssignedVerifier = "");
+            string currentVerifier = "");
 
 
     }

--- a/src/Portal/Portal/Helpers/IPageValidationHelper.cs.cs
+++ b/src/Portal/Portal/Helpers/IPageValidationHelper.cs.cs
@@ -68,7 +68,7 @@ namespace Portal.Helpers
         /// <param name="validationErrorMessages"></param>
         /// <param name="team"></param>
         /// <param name="formDataAssignedVerifier"></param>
-        /// <param name="currentVerifier"></param>
+        /// <param name="currentAssignedVerifierInDb"></param>
         /// <returns></returns>
         Task<bool> ValidateVerifyPage(string ion,
             string activityCode,
@@ -80,7 +80,7 @@ namespace Portal.Helpers
             string action,
             List<string> validationErrorMessages,
             string team,
-            string currentVerifier = "");
+            string currentAssignedVerifierInDb = "");
 
 
     }

--- a/src/Portal/Portal/Helpers/PageValidationHelper.cs
+++ b/src/Portal/Portal/Helpers/PageValidationHelper.cs
@@ -178,7 +178,7 @@ namespace Portal.Helpers
         /// <param name="action"></param>
         /// <param name="validationErrorMessages"></param>
         /// <param name="team"></param>
-        /// <param name="currentVerifier"></param>
+        /// <param name="currentAssignedVerifierInDb"></param>
         /// <returns></returns>
         public async Task<bool> ValidateVerifyPage(string ion,
             string activityCode,
@@ -190,20 +190,20 @@ namespace Portal.Helpers
             string action,
             List<string> validationErrorMessages,
             string team,
-            string currentVerifier = "")
+            string currentAssignedVerifierInDb = "")
         {
             var isValid = true;
 
-            if (action == "Done" || action == "Reject")
+            if (action == "Done")
             {
-                if (string.IsNullOrWhiteSpace(currentVerifier))
+                if (string.IsNullOrWhiteSpace(currentAssignedVerifierInDb))
                 {
                     validationErrorMessages.Add($"Operators: You are not assigned as the Verifier of this task. Please assign the task to yourself and click Save");
                     isValid = false;
                 }
-                else if (!currentUsername.Equals(currentVerifier, StringComparison.InvariantCultureIgnoreCase))
+                else if (!currentUsername.Equals(currentAssignedVerifierInDb, StringComparison.InvariantCultureIgnoreCase))
                 {
-                    validationErrorMessages.Add($"Operators: {currentVerifier} is assigned to this task. Please assign the task to yourself and click Save");
+                    validationErrorMessages.Add($"Operators: {currentAssignedVerifierInDb} is assigned to this task. Please assign the task to yourself and click Save");
                     isValid = false;
                 }
             }

--- a/src/Portal/Portal/Helpers/PageValidationHelper.cs
+++ b/src/Portal/Portal/Helpers/PageValidationHelper.cs
@@ -178,7 +178,7 @@ namespace Portal.Helpers
         /// <param name="action"></param>
         /// <param name="validationErrorMessages"></param>
         /// <param name="team"></param>
-        /// <param name="currentAssignedVerifier"></param>
+        /// <param name="currentVerifier"></param>
         /// <returns></returns>
         public async Task<bool> ValidateVerifyPage(string ion,
             string activityCode,
@@ -190,24 +190,22 @@ namespace Portal.Helpers
             string action,
             List<string> validationErrorMessages,
             string team,
-            string currentAssignedVerifier = "")
+            string currentVerifier = "")
         {
             var isValid = true;
 
             if (action == "Done" || action == "Reject")
             {
-                if (string.IsNullOrWhiteSpace(currentAssignedVerifier))
+                if (string.IsNullOrWhiteSpace(currentVerifier))
                 {
                     validationErrorMessages.Add($"Operators: You are not assigned as the Verifier of this task. Please assign the task to yourself and click Save");
                     isValid = false;
                 }
-                else if (!currentUsername.Equals(currentAssignedVerifier, StringComparison.InvariantCultureIgnoreCase))
+                else if (!currentUsername.Equals(currentVerifier, StringComparison.InvariantCultureIgnoreCase))
                 {
-                    validationErrorMessages.Add($"Operators: {currentAssignedVerifier} is assigned to this task. Please assign the task to yourself and click Save");
+                    validationErrorMessages.Add($"Operators: {currentVerifier} is assigned to this task. Please assign the task to yourself and click Save");
                     isValid = false;
                 }
-
-                return isValid;
             }
 
             if (!ValidateVerifyTaskInformation(ion, activityCode, sourceCategory, validationErrorMessages))

--- a/src/Portal/Portal/Helpers/PageValidationHelper.cs
+++ b/src/Portal/Portal/Helpers/PageValidationHelper.cs
@@ -116,7 +116,7 @@ namespace Portal.Helpers
             List<string> validationErrorMessages, string team)
         {
             var isValid = true;
-            
+
             if (action.Equals("Done", StringComparison.InvariantCultureIgnoreCase))
             {
                 if (string.IsNullOrWhiteSpace(currentAssignedAssessor))
@@ -136,12 +136,12 @@ namespace Portal.Helpers
                 isValid = false;
             }
 
-            if (!await ValidateOperators(assessor,"Assessor", validationErrorMessages))
+            if (!await ValidateOperators(assessor, "Assessor", validationErrorMessages))
             {
                 isValid = false;
             }
 
-            if (!await ValidateOperators(verifier,"Verifier", validationErrorMessages))
+            if (!await ValidateOperators(verifier, "Verifier", validationErrorMessages))
             {
                 isValid = false;
             }
@@ -171,27 +171,30 @@ namespace Portal.Helpers
         /// <param name="ion"></param>
         /// <param name="activityCode"></param>
         /// <param name="sourceCategory"></param>
-        /// <param name="currentAssignedVerifier"></param>
+        /// <param name="formDataAssignedVerifier"></param>
+        /// <param name="currentUsername"></param>
         /// <param name="recordProductAction"></param>
         /// <param name="dataImpacts"></param>
         /// <param name="action"></param>
         /// <param name="validationErrorMessages"></param>
         /// <param name="team"></param>
+        /// <param name="currentAssignedVerifier"></param>
         /// <returns></returns>
         public async Task<bool> ValidateVerifyPage(string ion,
             string activityCode,
             string sourceCategory,
-            string currentAssignedVerifier,
+            string formDataAssignedVerifier,
             string currentUsername,
             List<ProductAction> recordProductAction,
             List<DataImpact> dataImpacts,
             string action,
             List<string> validationErrorMessages,
-            string team)
+            string team,
+            string currentAssignedVerifier = "")
         {
             var isValid = true;
 
-            if (action == "Reject")
+            if (action == "Done" || action == "Reject")
             {
                 if (string.IsNullOrWhiteSpace(currentAssignedVerifier))
                 {
@@ -212,7 +215,7 @@ namespace Portal.Helpers
                 isValid = false;
             }
 
-            if (!await ValidateOperators(currentAssignedVerifier,"Verifier", validationErrorMessages))
+            if (!await ValidateOperators(formDataAssignedVerifier, "Verifier", validationErrorMessages))
             {
                 isValid = false;
             }

--- a/src/Portal/Portal/Pages/DbAssessment/Verify.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/Verify.cshtml.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Portal.Auth;
@@ -248,29 +249,29 @@ namespace Portal.Pages.DbAssessment
 
             ValidationErrorMessages.Clear();
 
-            if (string.IsNullOrWhiteSpace(comment))
-            {
-                _logger.LogError("Comment is null, empty or whitespace: {Comment}");
-                ValidationErrorMessages.Add($"Reject comment cannot be empty.");
+            var verifyData = await _dbContext.DbAssessmentVerifyData.FirstAsync(v => v.ProcessId == processId);
 
+            if (string.IsNullOrWhiteSpace(verifyData.Verifier))
+            {
+                ValidationErrorMessages.Add($"Operators: You are not assigned as the Verifier of this task. Please assign the task to yourself and click Save");
+            }
+            else if (!UserFullName.Equals(verifyData.Verifier, StringComparison.InvariantCultureIgnoreCase))
+            {
+                ValidationErrorMessages.Add($"Operators: {verifyData.Verifier} is assigned to this task. Please assign the task to yourself and click Save");
+            }
+            if (ValidationErrorMessages.Any())
+            {
                 return new JsonResult(this.ValidationErrorMessages)
                 {
                     StatusCode = (int)HttpStatusCode.BadRequest
                 };
             }
 
-            var verifyData = await _dbContext.DbAssessmentVerifyData.FirstAsync(v => v.ProcessId == processId);
-
-            if (!await _pageValidationHelper.ValidateVerifyPage(
-                Ion,
-                ActivityCode,
-                SourceCategory,
-                verifyData.Verifier,
-                UserFullName,
-                RecordProductAction,
-                DataImpacts, "Reject",
-                ValidationErrorMessages, Team, verifyData.Verifier))
+            if (string.IsNullOrWhiteSpace(comment))
             {
+                _logger.LogError("Comment is null, empty or whitespace: {Comment}");
+                ValidationErrorMessages.Add($"Reject comment cannot be empty.");
+
                 return new JsonResult(this.ValidationErrorMessages)
                 {
                     StatusCode = (int)HttpStatusCode.BadRequest

--- a/src/Portal/Portal/Pages/DbAssessment/Verify.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/Verify.cshtml.cs
@@ -169,15 +169,22 @@ namespace Portal.Pages.DbAssessment
 
                     return StatusCode((int)HttpStatusCode.OK);
                 case "Done":
+                    var verifyData =
+                        await _dbContext.DbAssessmentVerifyData.FirstAsync(t =>
+                            t.ProcessId == processId);
                     if (!await _pageValidationHelper.ValidateVerifyPage(
                                                                         Ion,
                                                                         ActivityCode,
                                                                         SourceCategory,
-                                                                        Verifier,
+                                                                        Verifier, // from submitted form data
                                                                         UserFullName,
                                                                         RecordProductAction,
-                                                                        DataImpacts, action,
-                                                                        ValidationErrorMessages, Team))
+                                                                        DataImpacts,
+                                                                        action,
+                                                                        ValidationErrorMessages,
+                                                                        Team,
+                                                                        verifyData.Verifier)) // from database
+
                     {
                         return new JsonResult(this.ValidationErrorMessages)
                         {
@@ -288,7 +295,7 @@ namespace Portal.Pages.DbAssessment
             {
                 return BadRequest(this.ValidationErrorMessages);
             }
-            
+
             await _commentsHelper.AddComment($"Verify Rejected: {comment}",
                 processId,
                 workflowInstance.WorkflowInstanceId,

--- a/src/Portal/Portal/Pages/DbAssessment/Verify.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/Verify.cshtml.cs
@@ -269,7 +269,7 @@ namespace Portal.Pages.DbAssessment
                 UserFullName,
                 RecordProductAction,
                 DataImpacts, "Reject",
-                ValidationErrorMessages, Team))
+                ValidationErrorMessages, Team, verifyData.Verifier))
             {
                 return new JsonResult(this.ValidationErrorMessages)
                 {


### PR DESCRIPTION
Error now shown to user if they click Done on the Verify page when they are not the assigned Verifier **in the database**.

I have plumbed it in best I can but not thrilled at the size and number of Helpers. I reworked the assigned verifier info being sent over to a Helper for validation, as it used what was in the form submission and not what was in the database, which might have introduced a security vulnerability. Perhaps a result of confused code responsibilities / bounded contexts the Helpers are encouraging.

I have not addressed the following yet as I'm not entirely sure it fits with the design approach we have taken so far. Do we really want modal as soon as page opens? Might frustrate users if they know how to use the site and fully intend to reassign if they feel like clicking Done. _'If I open a task that is at Verify that I am not currently assigned to; a validation warning is displayed and I am unable to complete the workflow.'_
