### PR TITLE
Features/run productactiontype postdeployment script

### DIFF
--- a/src/Databases/WorkflowDatabase/Scripts/Post Deployment/Main.sql
+++ b/src/Databases/WorkflowDatabase/Scripts/Post Deployment/Main.sql
@@ -1,0 +1,13 @@
+﻿/*
+Post-Deployment Script Template							
+--------------------------------------------------------------------------------------
+ This file contains SQL statements that will be appended to the build script.		
+ Use SQLCMD syntax to include a file in the post-deployment script.			
+ Example:      :r .\myfile.sql								
+ Use SQLCMD syntax to reference a variable in the post-deployment script.		
+ Example:      :setvar TableName MyTable							
+               SELECT * FROM [$(TableName)]					
+--------------------------------------------------------------------------------------
+*/
+:r .\AssignedTaskType.sql
+:r .\ProductActionType.sql

--- a/src/Databases/WorkflowDatabase/WorkflowDatabase.sqlproj
+++ b/src/Databases/WorkflowDatabase/WorkflowDatabase.sqlproj
@@ -78,7 +78,7 @@
     <Build Include="Tables\ProductAction.sql" />
     <Build Include="Tables\CachedHpdWorkspace.sql" />
     <Build Include="Tables\AssignedTaskType.sql" />
-    <PostDeploy Include="Scripts\Post Deployment\AssignedTaskType.sql" />
+    <None Include="Scripts\Post Deployment\AssignedTaskType.sql" />
     <Build Include="Tables\DbAssessmentAssignTask.sql" />
     <Build Include="Tables\DbAssessmentVerifyData.sql" />
     <Build Include="Tables\CarisProjectDetails.sql" />
@@ -93,5 +93,8 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Scripts\Post Deployment\ProductActionType.sql" />
+  </ItemGroup>
+  <ItemGroup>
+    <PostDeploy Include="Scripts\Post Deployment\Main.sql" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Workflow Database
- Create a single Main postdeployment script
  This is because you can have only one post deployment script.
  However, you can call other scripts from within a post deployment script.
  We want to call two scripts, so that ProductActionType actually runs.