### PR TITLE
Features/fix workflowcoordinator

### DIFF
--- a/src/WorkflowCoordinator/WorkflowCoordinator.UnitTests/AssessmentDataMappingProfileTests.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator.UnitTests/AssessmentDataMappingProfileTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using AutoMapper;
+using DataServices.Models;
+using NUnit.Framework;
+using WorkflowCoordinator.MappingProfiles;
+using WorkflowDatabase.EF.Models;
+
+namespace WorkflowCoordinator.UnitTests
+{
+    public class AssessmentDataMappingProfileTests
+    {
+        private Mapper _mapper;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mapper = new Mapper(new MapperConfiguration(mc => 
+                mc.AddProfile(new AssessmentDataMappingProfile())));
+        }
+
+        [Test]
+        public void Test_Given_DocumentAssessmentData_When_Mapped_Then_AssessmentData_Is_Populated()
+        {
+            //Arrange
+            var documentAssessmentData = new DocumentAssessmentData()
+            {
+                SdocId = 1,
+                Name = "NAME",
+                SDODate = DateTime.Today.AddDays(1),
+                Team = "TEAM",
+                DocumentType = "DOCUMENT_TYPE",
+                DocumentNature = "DOCUMENT_NATURE",
+                SourceName = "SOURCE_NAME"
+            };
+
+            //Act
+            var assessmentData = _mapper.Map<DocumentAssessmentData, AssessmentData>(
+                documentAssessmentData);
+
+            //Assert
+            Assert.IsNotNull(assessmentData);
+            Assert.AreEqual(documentAssessmentData.SdocId, assessmentData.PrimarySdocId);
+            Assert.AreEqual(documentAssessmentData.Name, assessmentData.SourceDocumentName);
+            Assert.AreEqual(documentAssessmentData.SDODate, assessmentData.ToSdoDate);
+            Assert.AreEqual(documentAssessmentData.Team, assessmentData.TeamDistributedTo);
+            Assert.AreEqual(documentAssessmentData.DocumentType, assessmentData.SourceDocumentType);
+            Assert.AreEqual(documentAssessmentData.DocumentNature, assessmentData.SourceNature);
+            Assert.AreEqual(documentAssessmentData.SourceName, assessmentData.RsdraNumber);
+
+
+        }
+    }
+}

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Handlers/PersistWorkflowInstanceDataEventHandler.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Handlers/PersistWorkflowInstanceDataEventHandler.cs
@@ -32,7 +32,7 @@ namespace WorkflowCoordinator.Handlers
             LogContext.PushProperty("MessageId", context.MessageId);
             LogContext.PushProperty("Message", message.ToJSONSerializedString());
             LogContext.PushProperty("EventName", nameof(PersistWorkflowInstanceDataEvent));
-            LogContext.PushProperty("CorrelationId", message.CorrelationId);
+            LogContext.PushProperty("MessageCorrelationId", message.CorrelationId);
             LogContext.PushProperty("ProcessId", message.ProcessId);
             LogContext.PushProperty("FromActivity", message.FromActivity);
             LogContext.PushProperty("ToActivity", message.ToActivity);

--- a/src/WorkflowCoordinator/WorkflowCoordinator/LoggingHelper.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/LoggingHelper.cs
@@ -31,7 +31,7 @@ namespace WorkflowCoordinator
                     new SqlColumn
                         {ColumnName = "EventName", DataType = SqlDbType.NVarChar, DataLength = 255},
                     new SqlColumn
-                        {ColumnName = "CorrelationId", DataType = SqlDbType.NVarChar, DataLength = 255},
+                        {ColumnName = "MessageCorrelationId", DataType = SqlDbType.NVarChar, DataLength = 255},
                     new SqlColumn
                         {ColumnName = "ProcessId", DataType = SqlDbType.Int}
                 }

--- a/src/WorkflowCoordinator/WorkflowCoordinator/LoggingHelper.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/LoggingHelper.cs
@@ -41,6 +41,7 @@ namespace WorkflowCoordinator
                 .MinimumLevel.Is(logLevel)
                 .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
                 .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning)
+                .MinimumLevel.Override("System", LogEventLevel.Warning)
                 .Enrich.FromLogContext()
                 .WriteTo.Console()
                 .WriteTo.MSSqlServer(loggingConnectionString,

--- a/src/WorkflowCoordinator/WorkflowCoordinator/MappingProfiles/AssessmentDataMappingProfile.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/MappingProfiles/AssessmentDataMappingProfile.cs
@@ -9,6 +9,8 @@ namespace WorkflowCoordinator.MappingProfiles
         public AssessmentDataMappingProfile()
         {
             CreateMap<DocumentAssessmentData, AssessmentData>()
+                .ForMember(destination => destination.PrimarySdocId,
+                    opts => opts.MapFrom(source => source.SdocId))
                 .ForMember(destination => destination.SourceDocumentName,
                     opts => opts.MapFrom(source => source.Name))
                 .ForMember(destination => destination.ToSdoDate,

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Sagas/AssessmentPollingSaga.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Sagas/AssessmentPollingSaga.cs
@@ -56,7 +56,7 @@ namespace WorkflowCoordinator.Sagas
         public async Task Timeout(ExecuteAssessmentPollingTask state, IMessageHandlerContext context)
         {
             LogContext.PushProperty("MessageId", context.MessageId);
-            LogContext.PushProperty("CorrelationId", "");
+            LogContext.PushProperty("MessageCorrelationId", "");
             LogContext.PushProperty("EventName", nameof(ExecuteAssessmentPollingTask));
             LogContext.PushProperty("ProcessId", 0);
 

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Sagas/StartDbAssessmentSaga.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Sagas/StartDbAssessmentSaga.cs
@@ -192,6 +192,8 @@ namespace WorkflowCoordinator.Sagas
 
         private async void ConstructAndSendLinkedDocumentRetrievalCommands(IMessageHandlerContext context)
         {
+            _logger.LogInformation($"Sending {nameof(GetBackwardDocumentLinksCommand)}");
+
             var backwardDocumentLinkCommand = new GetBackwardDocumentLinksCommand()
             {
                 CorrelationId = Data.CorrelationId,
@@ -201,6 +203,8 @@ namespace WorkflowCoordinator.Sagas
 
             await context.Send(backwardDocumentLinkCommand).ConfigureAwait(false);
 
+            _logger.LogInformation($"Sending {nameof(GetForwardDocumentLinksCommand)}");
+
             var forwardDocumentLinkCommand = new GetForwardDocumentLinksCommand()
             {
                 CorrelationId = Data.CorrelationId,
@@ -209,6 +213,8 @@ namespace WorkflowCoordinator.Sagas
             };
 
             await context.Send(forwardDocumentLinkCommand).ConfigureAwait(false);
+
+            _logger.LogInformation($"Sending {nameof(GetSepDocumentLinksCommand)}");
 
             var sepDocumentLinkCommand = new GetSepDocumentLinksCommand()
             {

--- a/src/WorkflowCoordinator/WorkflowCoordinator/WorkflowCoordinatorConfig.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/WorkflowCoordinatorConfig.cs
@@ -84,6 +84,9 @@ namespace WorkflowCoordinator
             });
             persistence.SubscriptionSettings().CacheFor(TimeSpan.FromMinutes(1));
 
+            this.AuditProcessedMessagesTo("audit", TimeSpan.FromMinutes(10));
+            this.SendFailedMessagesTo("error");
+
             // Additional config
 
             this.Conventions()


### PR DESCRIPTION
### WorkflowCoordinator
- Set PrimarySdocId on AssessmentData
- Log when sending certain messages
- Rename Logging column CorrelationId to MessageCorrelationId to prevent NSB message header CorrelationId being logged rather than the NSB message body
- Reduce logging for DataServiceApiClient to make logs more readable
- Audit NSB messages so that successful messages appear in ServiceInsight

### WorkflowCoordinator.UnitTests
- Add unit test to assert that RetrieveAssessmentDataCommand adds AssessmentData
