### PR TITLE
Features/fix sdoccoordinator

### DIFF
--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Config/NsbConfig.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Config/NsbConfig.cs
@@ -7,6 +7,7 @@ namespace SourceDocumentCoordinator.Config
         public bool IsLocalDevelopment { get; set; }
         public string SourceDocumentCoordinatorName { get; set; }
         public string EventServiceName { get; set; }
+        public string WorkflowCoordinatorName { get; set; }
         public string LocalDbServer { get; set; }
         public Uri AzureDbTokenUrl { get; set; }
     }

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/LoggingHelper.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/LoggingHelper.cs
@@ -41,6 +41,7 @@ namespace SourceDocumentCoordinator
                 .MinimumLevel.Is(logLevel)
                 .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
                 .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning)
+                .MinimumLevel.Override("System", LogEventLevel.Warning)
                 .Enrich.FromLogContext()
                 .WriteTo.Console()
                 .WriteTo.MSSqlServer(loggingConnectionString,

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/LoggingHelper.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/LoggingHelper.cs
@@ -31,7 +31,7 @@ namespace SourceDocumentCoordinator
                     new SqlColumn
                         {ColumnName = "EventName", DataType = SqlDbType.NVarChar, DataLength = 255},
                     new SqlColumn
-                        {ColumnName = "CorrelationId", DataType = SqlDbType.NVarChar, DataLength = 255},
+                        {ColumnName = "MessageCorrelationId", DataType = SqlDbType.NVarChar, DataLength = 255},
                     new SqlColumn
                         {ColumnName = "ProcessId", DataType = SqlDbType.Int}
                 }

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Sagas/SourceDocumentRetrievalSaga.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Sagas/SourceDocumentRetrievalSaga.cs
@@ -45,7 +45,7 @@ namespace SourceDocumentCoordinator.Sagas
         public async Task Handle(InitiateSourceDocumentRetrievalEvent message, IMessageHandlerContext context)
         {
             LogContext.PushProperty("MessageId", context.MessageId);
-            LogContext.PushProperty("CorrelationId", message.CorrelationId);
+            LogContext.PushProperty("MessageCorrelationId", message.CorrelationId);
             LogContext.PushProperty("EventName", nameof(InitiateSourceDocumentRetrievalEvent));
             LogContext.PushProperty("ProcessId", 0);
 

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/SourceDocumentCoordinatorConfig.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/SourceDocumentCoordinatorConfig.cs
@@ -67,6 +67,9 @@ namespace SourceDocumentCoordinator
             });
             persistence.SubscriptionSettings().CacheFor(TimeSpan.FromMinutes(1));
 
+            this.AuditProcessedMessagesTo("audit", TimeSpan.FromMinutes(10));
+            this.SendFailedMessagesTo("error");
+
             // Additional config
 
             this.Conventions()

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/SourceDocumentCoordinatorConfig.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/SourceDocumentCoordinatorConfig.cs
@@ -42,6 +42,10 @@ namespace SourceDocumentCoordinator
                 assembly: typeof(InitiateSourceDocumentRetrievalEvent).Assembly,
                 publisherEndpoint: nsbConfig.EventServiceName);
 
+            routing.RegisterPublisher(
+                assembly: typeof(InitiateSourceDocumentRetrievalEvent).Assembly,
+                publisherEndpoint: nsbConfig.WorkflowCoordinatorName);
+
             // Persistence
 
             var persistence = this.UsePersistence<SqlPersistence>();


### PR DESCRIPTION
### SourceDocumentCoordinator
- Reduce logging for DataServiceApiClient to make logs more readable
- Rename Logging column CorrelationId to MessageCorrelationId to prevent NSB message header CorrelationId being logged rather than the NSB message body
- Register WorkflowCoordinator as publisher of InitiateSourceDocumentRetrievalEvent
- Audit NSB messages so that successful messages appear in ServiceInsight