### PR TITLE
Removed NCNE workflow test

### DIFF
--- a/src/NCNEPortal.TestAutomation.Specs/WorkflowPage.feature
+++ b/src/NCNEPortal.TestAutomation.Specs/WorkflowPage.feature
@@ -1,5 +1,0 @@
-﻿Feature: WorkflowPage
-
-Scenario: The Workflow Page loads
-Given I navigate to the NCNE Workflow page
- Then The NCNE Workflow page has loaded


### PR DESCRIPTION
The Workflow test is not fit for purpose and is failing the pipeline for no good reason.
When navigating to the Workflow page a processID is required which means that a test to ensure it is loading is more complicated