### PR TITLE
Accessibility: Portal landing page contrasts

### DIFF
--- a/src/Portal/Portal/Pages/Index.cshtml
+++ b/src/Portal/Portal/Pages/Index.cshtml
@@ -64,21 +64,21 @@
                             <a asp-page="DbAssessment/@task.TaskStage" asp-route-ProcessId="@task.ProcessId">@task.ProcessId</a>
                         </td>
                         <td>
-                            <span class="@(task.DaysToDmEndDateAmberAlert ? "alertText amber" : "") @(task.DaysToDmEndDateRedAlert ? "alertText red" : "")">
+                            <div class="@(task.DaysToDmEndDateAmberAlert ? "alertText amber" : "") @(task.DaysToDmEndDateRedAlert ? "alertText red" : "")">
                                 @task.DaysToDmEndDate
-                            </span>
+                            </div>
                         </td>
                         <td>
                             @task.DmEndDate.ToShortDateString()
                         </td>
                         <td>
                             <span>@Html.DisplayFor(model => task.OnHoldDays)</span>
-                            <span class="float-right mr-1">
+                            <span class="float-right mr-2">
                                 @if (task.IsOnHold)
                                 {
-                                    <i class="fa fa-circle" style="@(task.OnHoldDaysGreen ? "color: green" : "") @(task.OnHoldDaysAmber ? "color: darkorange" : "") @(task.OnHoldDaysRed ? "color: red": "")"></i>
-                                    <i class="fa fa-circle" style="@(task.OnHoldDaysGreen ? "display:none" : "") @(task.OnHoldDaysAmber ? "color: darkorange" : "") @(task.OnHoldDaysRed ? "color: red" : "")"></i>
-                                    <i class="fa fa-circle" style="@(task.OnHoldDaysRed ? "color: red": "display: none")"></i>
+                                    <i class="fa fa-circle fa-sm @(task.OnHoldDaysGreen ? "onHoldGreenCircle" : "") @(task.OnHoldDaysAmber ? "onHoldAmberCircle" : "") @(task.OnHoldDaysRed ? "onHoldRedCircle": "")"></i>
+                                    <i class="fa fa-circle fa-sm @(task.OnHoldDaysAmber ? "onHoldAmberCircle" : "") @(task.OnHoldDaysRed ? "onHoldRedCircle" : "")" @(task.OnHoldDaysGreen ? "style='display: none'" : "")></i>
+                                    <i class="fa fa-circle fa-sm @(task.OnHoldDaysRed ? "onHoldRedCircle": "")" @(task.OnHoldDaysRed ? "" : "style='display: none'")></i>
                                 }
                             </span>
                         </td>
@@ -154,21 +154,21 @@
                             <a asp-page="DbAssessment/@task.TaskStage" asp-route-ProcessId="@task.ProcessId">@task.ProcessId</a>
                         </td>
                         <td>
-                            <span class="@(task.DaysToDmEndDateAmberAlert ? "alertText amber" : "") @(task.DaysToDmEndDateRedAlert ? "alertText red" : "")">
+                            <div class="@(task.DaysToDmEndDateAmberAlert ? "alertText amber" : "") @(task.DaysToDmEndDateRedAlert ? "alertText red" : "")">
                                 @task.DaysToDmEndDate
-                            </span>
+                            </div>
                         </td>
                         <td>
                             @task.DmEndDate.ToShortDateString()
                         </td>
                         <td>
                             <span>@Html.DisplayFor(model => task.OnHoldDays)</span>
-                            <span class="float-right mr-1">
+                            <span class="float-right mr-2">
                                 @if (task.IsOnHold)
                                 {
-                                    <i class="fa fa-circle" style="@(task.OnHoldDaysGreen ? "color: green" : "") @(task.OnHoldDaysAmber ? "color: darkorange" : "") @(task.OnHoldDaysRed ? "color: red": "")"></i>
-                                    <i class="fa fa-circle" style="@(task.OnHoldDaysGreen ? "display:none" : "") @(task.OnHoldDaysAmber ? "color: darkorange" : "") @(task.OnHoldDaysRed ? "color: red" : "")"></i>
-                                    <i class="fa fa-circle" style="@(task.OnHoldDaysRed ? "color: red": "display: none")"></i>
+                                    <i class="fa fa-circle fa-sm @(task.OnHoldDaysGreen ? "onHoldGreenCircle" : "") @(task.OnHoldDaysAmber ? "onHoldAmberCircle" : "") @(task.OnHoldDaysRed ? "onHoldRedCircle": "")"></i>
+                                    <i class="fa fa-circle fa-sm @(task.OnHoldDaysAmber ? "onHoldAmberCircle" : "") @(task.OnHoldDaysRed ? "onHoldRedCircle" : "")" @(task.OnHoldDaysGreen ? "style='display: none'" : "")></i>
+                                    <i class="fa fa-circle fa-sm @(task.OnHoldDaysRed ? "onHoldRedCircle": "")" @(task.OnHoldDaysRed ? "" : "style='display: none'")></i>
                                 }
                             </span>
                         </td>

--- a/src/Portal/Portal/wwwroot/css/site.css
+++ b/src/Portal/Portal/wwwroot/css/site.css
@@ -8,6 +8,10 @@ body {
     font-weight: 300;
 }
 
+a {
+    color: #0062DC;
+}
+
 /* Start chevron for notes on landing page */
 table.dataTable td.details-control i:before {
     content: '\f078';
@@ -442,7 +446,7 @@ body, .sticky-footer-wrapper {
 
 /* START of pagination matching UKHO design system */
 
-.page-link {
+.pagination .page-link {
     position: relative;
     display: block;
     padding: 0.5rem 0.75rem;
@@ -452,6 +456,12 @@ body, .sticky-footer-wrapper {
     background-color: #fff;
     border: 1px solid #dee2e6;
 }
+
+.page-item.active .page-link {
+    background-color: #007e97;
+    border: 1px solid #007e97;
+}
+
 
 /* Square off prev/next buttons button corners */
 .page-item:last-child .page-link {
@@ -468,11 +478,13 @@ body, .sticky-footer-wrapper {
 .pagination > li:first-child a {
     background-color: #09315B;
     color: #ffffff;
+    border: 1px solid #09315B;
 }
 
 .pagination > li:last-child a {
     background-color: #09315B;
     color: #ffffff;
+    border: 1px solid #09315B;
 }
 
 .page-link:focus {
@@ -485,14 +497,15 @@ body, .sticky-footer-wrapper {
 .pagination .page-item:last-child .page-link:active {
     color: #09315B;
     background-color: #ffffff;
-    border-color: #09315B;
+    border: 1px solid #09315B;
 }
 
 .pagination .page-item:first-child .page-link:active {
     color: #09315B;
     background-color: #ffffff;
-    border-color: #09315B;
+    border: 1px solid #09315B;
 }
+
 /* END of pagination matching UKHO design system */
 
 /* Start UKHO design system error dialog stuff*/

--- a/src/Portal/Portal/wwwroot/css/site.css
+++ b/src/Portal/Portal/wwwroot/css/site.css
@@ -308,6 +308,12 @@ table > tbody > tr > th {
 }
 
 
+.buttonSelected {
+    background-color: #007e97;
+    color: #fff;
+    font-weight: 400;
+}
+
 /* DAYS ON HOLD WARNING START */
 .onHoldRedCircle {
     color: #cd2026;

--- a/src/Portal/Portal/wwwroot/css/site.css
+++ b/src/Portal/Portal/wwwroot/css/site.css
@@ -307,14 +307,31 @@ table > tbody > tr > th {
     width: 68px;
 }
 
+
+/* DAYS ON HOLD WARNING START */
+.onHoldRedCircle {
+    color: #cd2026;
+}
+.onHoldAmberCircle {
+    color: #ff8c00;
+}
+.onHoldGreenCircle {
+    color: #008000;
+}
+/* DAYS ON HOLD WARNING END */
+
 .alertText {
     border-radius: .25rem;
-    padding: .25rem .50rem;
     color: white;
+    font-weight: 400;
+    min-width: 1rem;
+    max-width: 3.0rem;
+    max-height: 1.75rem;
+    text-align: center;
 }
 
     .alertText.red {
-        background-color: red;
+        background-color: #cd2026;
     }
 
     .alertText.amber {

--- a/src/Portal/Portal/wwwroot/js/Index.js
+++ b/src/Portal/Portal/wwwroot/js/Index.js
@@ -216,11 +216,11 @@
     function setMenuItemSelection() {
         $("#menuItemList button").each(function (index) {
             if (index === menuItem) {
-                $(this).addClass("btn-info");
+                $(this).addClass("buttonSelected");
                 $(this).removeClass("btn-primary");
 
             } else {
-                $(this).removeClass("btn-info");
+                $(this).removeClass("buttonSelected");
                 $(this).addClass("btn-primary");
             }
         });


### PR DESCRIPTION
**Days to DM End Date on landing page:** 

- Darker red to fix contrast as per WCAG warning.
- Ensured all red boxes are the same size (just for aesthetics!).

Probably won't work for > -999. Surely they don't get left that long? :)

**Days On Hold:**

- Introduced classes for all 3 warning circle colours. I think we need to have a set of these more generally to ensure all colours are consistent.
- Switched red to that set above.
- Reduced circle size.

**Fix contrast of button selected colour on landing page:**

- New class `buttonSelected` using UKHO design system teal, in place of the aqua from bnt-info class.

**Fix contrast on task links and pagination:**

- Darken all link blues with 'a' element selector CSS.
- Change active pagination page button to same teal as selected buttons.
- Clean up look of pagination borders.

Left hover colour the same for buttons top of page now that colour of active page has changed for pagination.