### PR TITLE
Features/add assessment complete command

### DIFF
--- a/src/Common/Common.Messages/Commands/CompleteAssessmentCommand.cs
+++ b/src/Common/Common.Messages/Commands/CompleteAssessmentCommand.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Common.Messages.Commands
+{
+    public class CompleteAssessmentCommand : ICorrelate
+    {
+        public Guid CorrelationId { get; set; }
+        public int ProcessId { get; set; }  
+    }
+}

--- a/src/DataServices/DataServices/Controllers/AssessmentApi.cs
+++ b/src/DataServices/DataServices/Controllers/AssessmentApi.cs
@@ -117,17 +117,17 @@ namespace DataServices.Controllers
         [HttpPut]
         [Route("/DataServices/v1/SourceDocument/Assessment/AssessmentCompleted/{callerCode}/{sdocId}")]
         [ValidateModelState]
-        [SwaggerOperation("MarkAssessmentAsCompleted")]
+        [SwaggerOperation("PutAssessmentAsCompleted")]
         [SwaggerResponse(statusCode: 400, type: typeof(DefaultErrorResponse), description: "Bad request.")]
         [SwaggerResponse(statusCode: 401, type: typeof(DefaultErrorResponse), description: "Unauthorised.")]
         [SwaggerResponse(statusCode: 403, type: typeof(DefaultErrorResponse), description: "Forbidden.")]
         [SwaggerResponse(statusCode: 404, type: typeof(DefaultErrorResponse), description: "Not found.")]
         [SwaggerResponse(statusCode: 406, type: typeof(DefaultErrorResponse), description: "Not acceptable.")]
         [SwaggerResponse(statusCode: 500, type: typeof(DefaultErrorResponse), description: "Internal Server Error.")]
-        public async Task<IActionResult> MarkAssessmentAsCompleted([FromRoute] [Required] string callerCode,
+        public async Task<IActionResult> PutAssessmentAsCompleted([FromRoute] [Required] string callerCode,
             [FromRoute] [Required] int? sdocId, [FromQuery] [Required] string comment)
         {
-            LogContext.PushProperty("ApiResource", nameof(MarkAssessmentAsCompleted));
+            LogContext.PushProperty("ApiResource", nameof(PutAssessmentAsCompleted));
             LogContext.PushProperty("CallerCode", callerCode);
             LogContext.PushProperty("SdocId", sdocId);
             LogContext.PushProperty("Comment", comment);
@@ -194,14 +194,14 @@ namespace DataServices.Controllers
         [HttpPut]
         [Route("/DataServices/v1/SourceDocument/Assessment/DocumentAssessed/{callerCode}/{transactionId}/{sdocId}/{actionType}/{change}")]
         [ValidateModelState]
-        [SwaggerOperation("MarkDocumentAsAssessed")]
+        [SwaggerOperation("PutDocumentAsAssessed")]
         [SwaggerResponse(statusCode: 400, type: typeof(DefaultErrorResponse), description: "Bad request.")]
         [SwaggerResponse(statusCode: 401, type: typeof(DefaultErrorResponse), description: "Unauthorised.")]
         [SwaggerResponse(statusCode: 403, type: typeof(DefaultErrorResponse), description: "Forbidden.")]
         [SwaggerResponse(statusCode: 404, type: typeof(DefaultErrorResponse), description: "Not found.")]
         [SwaggerResponse(statusCode: 406, type: typeof(DefaultErrorResponse), description: "Not acceptable.")]
         [SwaggerResponse(statusCode: 500, type: typeof(DefaultErrorResponse), description: "Internal Server Error.")]
-        public async Task<IActionResult> MarkDocumentAsAssessed(
+        public async Task<IActionResult> PutDocumentAsAssessed(
                                                             [FromRoute][Required]string callerCode, 
                                                             [FromRoute][Required]string transactionId,
                                                             [FromRoute][Required]int? sdocId,
@@ -209,7 +209,7 @@ namespace DataServices.Controllers
                                                             [FromRoute][Required]string change)
         {
 
-            LogContext.PushProperty("ApiResource", nameof(MarkDocumentAsAssessed));
+            LogContext.PushProperty("ApiResource", nameof(PutDocumentAsAssessed));
             LogContext.PushProperty("CallerCode", callerCode);
             LogContext.PushProperty("SdocId", sdocId??0);
             LogContext.PushProperty("TransactionId", transactionId);

--- a/src/DataServices/DataServices/Controllers/AssessmentApi.cs
+++ b/src/DataServices/DataServices/Controllers/AssessmentApi.cs
@@ -117,17 +117,17 @@ namespace DataServices.Controllers
         [HttpPut]
         [Route("/DataServices/v1/SourceDocument/Assessment/AssessmentCompleted/{callerCode}/{sdocId}")]
         [ValidateModelState]
-        [SwaggerOperation("PutAssessmentCompleted")]
+        [SwaggerOperation("MarkAssessmentAsCompleted")]
         [SwaggerResponse(statusCode: 400, type: typeof(DefaultErrorResponse), description: "Bad request.")]
         [SwaggerResponse(statusCode: 401, type: typeof(DefaultErrorResponse), description: "Unauthorised.")]
         [SwaggerResponse(statusCode: 403, type: typeof(DefaultErrorResponse), description: "Forbidden.")]
         [SwaggerResponse(statusCode: 404, type: typeof(DefaultErrorResponse), description: "Not found.")]
         [SwaggerResponse(statusCode: 406, type: typeof(DefaultErrorResponse), description: "Not acceptable.")]
         [SwaggerResponse(statusCode: 500, type: typeof(DefaultErrorResponse), description: "Internal Server Error.")]
-        public async Task<IActionResult> PutAssessmentCompleted([FromRoute] [Required] string callerCode,
+        public async Task<IActionResult> MarkAssessmentAsCompleted([FromRoute] [Required] string callerCode,
             [FromRoute] [Required] int? sdocId, [FromQuery] [Required] string comment)
         {
-            LogContext.PushProperty("ApiResource", nameof(PutAssessmentCompleted));
+            LogContext.PushProperty("ApiResource", nameof(MarkAssessmentAsCompleted));
             LogContext.PushProperty("CallerCode", callerCode);
             LogContext.PushProperty("SdocId", sdocId);
             LogContext.PushProperty("Comment", comment);

--- a/src/DataServices/DataServices/Controllers/AssessmentApi.cs
+++ b/src/DataServices/DataServices/Controllers/AssessmentApi.cs
@@ -182,7 +182,7 @@ namespace DataServices.Controllers
         /// <param name="callerCode">System that is calling the API  Example: HDB </param>
         /// <param name="transactionId">Cross reference from SDRA to  external system providing the assessment record   Example: tbc </param>
         /// <param name="sdocId">Unique identifier for an SDRA Source Document   Example:  </param>
-        /// <param name="action">A action type from a list  Example: Imm Act - NM, Longer-term Action, No Action, No Impact </param>
+        /// <param name="actionType">A action type from a list  Example: Imm Act - NM, Longer-term Action, No Action, No Impact </param>
         /// <param name="change">tbc  Example: tbc </param>
         /// <response code="200">SDRA notified that document has been assessment</response>
         /// <response code="400">Bad request.</response>
@@ -194,37 +194,81 @@ namespace DataServices.Controllers
         [HttpPut]
         [Route("/DataServices/v1/SourceDocument/Assessment/DocumentAssessed/{callerCode}/{transactionId}/{sdocId}/{actionType}/{change}")]
         [ValidateModelState]
-        [SwaggerOperation("PutDocumentAssessed")]
+        [SwaggerOperation("MarkDocumentAsAssessed")]
         [SwaggerResponse(statusCode: 400, type: typeof(DefaultErrorResponse), description: "Bad request.")]
         [SwaggerResponse(statusCode: 401, type: typeof(DefaultErrorResponse), description: "Unauthorised.")]
         [SwaggerResponse(statusCode: 403, type: typeof(DefaultErrorResponse), description: "Forbidden.")]
         [SwaggerResponse(statusCode: 404, type: typeof(DefaultErrorResponse), description: "Not found.")]
         [SwaggerResponse(statusCode: 406, type: typeof(DefaultErrorResponse), description: "Not acceptable.")]
         [SwaggerResponse(statusCode: 500, type: typeof(DefaultErrorResponse), description: "Internal Server Error.")]
-        public async Task<IActionResult> PutDocumentAssessed([FromRoute][Required]string callerCode, [FromRoute][Required]string transactionId, [FromRoute][Required]int? sdocId, [FromRoute][Required]string actionType, [FromRoute][Required]string change)
+        public async Task<IActionResult> MarkDocumentAsAssessed(
+                                                            [FromRoute][Required]string callerCode, 
+                                                            [FromRoute][Required]string transactionId,
+                                                            [FromRoute][Required]int? sdocId,
+                                                            [FromRoute][Required]string actionType, 
+                                                            [FromRoute][Required]string change)
         {
-            //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
-            // return StatusCode(200);
 
-            //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
-            // return StatusCode(400, default(DefaultErrorResponse));
+            LogContext.PushProperty("ApiResource", nameof(MarkDocumentAsAssessed));
+            LogContext.PushProperty("CallerCode", callerCode);
+            LogContext.PushProperty("SdocId", sdocId??0);
+            LogContext.PushProperty("TransactionId", transactionId);
+            LogContext.PushProperty("ActionType", actionType);
+            LogContext.PushProperty("Change", change);
 
-            //TODO: Uncomment the next line to return response 401 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
-            // return StatusCode(401, default(DefaultErrorResponse));
+            _logger.LogInformation("{ApiResource} entered with: CallerCode: {CallerCode}; " +
+                                               "SdocId: {SdocId}; " +
+                                               "TransactionId: {TransactionId}; " +
+                                               "ActionType: {ActionType}; " +
+                                               "Change: {Change}");
 
-            //TODO: Uncomment the next line to return response 403 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
-            // return StatusCode(403, default(DefaultErrorResponse));
+            if (!sdocId.HasValue || sdocId <= 0)
+                throw new ArgumentException("Error marking assessment Assessed due to invalid parameter", nameof(sdocId));
 
-            //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
-            // return StatusCode(404, default(DefaultErrorResponse));
+            CallOutcome result;
 
-            //TODO: Uncomment the next line to return response 406 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
-            // return StatusCode(406, default(DefaultErrorResponse));
+            try
+            {
+                var notifyAssessmentCompletedRequest = new NotifyDocumentAssessedRequest(
+                                                    new NotifyDocumentAssessedRequestBody(
+                                                                                            callerCode, 
+                                                                                            transactionId, 
+                                                                                            sdocId.Value,
+                                                                                            0, 
+                                                                                            null,
+                                                                                            actionType, 
+                                                                                            change));
 
-            //TODO: Uncomment the next line to return response 500 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
-            // return StatusCode(500, default(DefaultErrorResponse));
+                LogContext.PushProperty("WebServiceRequestResource", nameof(_assessmentWebServiceSoapClientAdapter.SoapClient.NotifyDocumentAssessedAsync));
+                LogContext.PushProperty("WebServiceRequestBody", notifyAssessmentCompletedRequest.Body.ToJSONSerializedString());
+                _logger.LogInformation("{ApiResource} requesting Web Service {WebServiceRequestResource} with: WebServiceRequestBody: {@WebServiceRequestBody};");
 
-            throw new NotImplementedException();
+                var task = await _assessmentWebServiceSoapClientAdapter.SoapClient.NotifyDocumentAssessedAsync(notifyAssessmentCompletedRequest);
+
+                _logger.LogInformation("{ApiResource} finished requesting Web Service {WebServiceRequestResource} successfully");
+
+                result = task.Body.NotifyDocumentAssessedResult;
+            }
+            catch (AggregateException e) when (e.InnerException is System.ServiceModel.EndpointNotFoundException)
+            {
+                _logger.LogError(e, "{ApiResource} Endpoint not found");
+                return StatusCode(500, e.Message);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "{ApiResource} Error marking assessment Assessed");
+                return StatusCode(500, e.Message);
+            }
+
+            if (result.ErrorCode != 0)
+            {
+                LogContext.PushProperty("WebServiceResponseMessage", result.Message);
+                _logger.LogError("{ApiResource} Error marking assessment Assessed, WebServiceResponseMessage: {WebServiceResponseMessage}");
+
+                return StatusCode(500, $"Error marking assessment Assessed, Message: {result.Message}");
+            }
+
+            return new ObjectResult(HttpStatusCode.OK);
         }
     }
 }

--- a/src/Databases/WorkflowDatabase.EF/LinkedDocumentRetrievalStatus.cs
+++ b/src/Databases/WorkflowDatabase.EF/LinkedDocumentRetrievalStatus.cs
@@ -5,7 +5,7 @@
         NotAttached,
         Started,    // Equivalent to SDRA Status 1 (Queued)
         Ready,       // Equivalent to SDRA Status 0 (success)
-        Complete
+        FileGenerated
 
     }
 }

--- a/src/Databases/WorkflowDatabase.EF/LinkedDocumentRetrievalStatus.cs
+++ b/src/Databases/WorkflowDatabase.EF/LinkedDocumentRetrievalStatus.cs
@@ -5,7 +5,9 @@
         NotAttached,
         Started,    // Equivalent to SDRA Status 1 (Queued)
         Ready,       // Equivalent to SDRA Status 0 (success)
-        FileGenerated
+        FileGenerated,
+        Assessed,
+        Completed
 
     }
 }

--- a/src/Databases/WorkflowDatabase.EF/SourceDocumentRetrievalStatus.cs
+++ b/src/Databases/WorkflowDatabase.EF/SourceDocumentRetrievalStatus.cs
@@ -4,6 +4,6 @@
     {
         Started,    // Equivalent to SDRA Status 1 (Queued)
         Ready,       // Equivalent to SDRA Status 0 (success)
-        Complete
+        FileGenerated
     }
 }

--- a/src/Databases/WorkflowDatabase.EF/SourceDocumentRetrievalStatus.cs
+++ b/src/Databases/WorkflowDatabase.EF/SourceDocumentRetrievalStatus.cs
@@ -4,6 +4,8 @@
     {
         Started,    // Equivalent to SDRA Status 1 (Queued)
         Ready,       // Equivalent to SDRA Status 0 (success)
-        FileGenerated
+        FileGenerated,
+        Assessed,
+        Completed
     }
 }

--- a/src/Portal/Portal/Configuration/UriConfig.cs
+++ b/src/Portal/Portal/Configuration/UriConfig.cs
@@ -20,7 +20,7 @@ namespace Portal.Configuration
         public Uri LocalDevLandingPageHttpsUrl { get; set; }
         public Uri LandingPageUrl { get; set; }
 
-        public Uri BuildDataServicesUri(string callerCode, int sdocId, string comment)
+        public Uri BuildDataServicesMarkAssessmentCompletedUri(string callerCode, int sdocId, string comment)
         {
             return new Uri(
                 ConfigHelpers.IsLocalDevelopment ? DataAccessLocalhostBaseUri : DataServicesWebServiceBaseUri,

--- a/src/Portal/Portal/HttpClients/DataServiceApiClient.cs
+++ b/src/Portal/Portal/HttpClients/DataServiceApiClient.cs
@@ -22,7 +22,7 @@ namespace Portal.HttpClients
             _uriConfig = uriConfig;
         }
 
-        public async Task PutAssessmentCompleted(int sdocId, string comment)
+        public async Task MarkAssessmentAsCompleted(int sdocId, string comment)
         {
             var data = "";
             var fullUri = _uriConfig.Value.BuildDataServicesUri(_generalConfig.Value.CallerCode, sdocId, comment);

--- a/src/Portal/Portal/HttpClients/DataServiceApiClient.cs
+++ b/src/Portal/Portal/HttpClients/DataServiceApiClient.cs
@@ -25,7 +25,7 @@ namespace Portal.HttpClients
         public async Task MarkAssessmentAsCompleted(int sdocId, string comment)
         {
             var data = "";
-            var fullUri = _uriConfig.Value.BuildDataServicesUri(_generalConfig.Value.CallerCode, sdocId, comment);
+            var fullUri = _uriConfig.Value.BuildDataServicesMarkAssessmentCompletedUri(_generalConfig.Value.CallerCode, sdocId, comment);
 
             using (var response = await _httpClient.PutAsync(fullUri.ToString(), null).ConfigureAwait(false))
             {

--- a/src/Portal/Portal/HttpClients/IDataServiceApiClient.cs
+++ b/src/Portal/Portal/HttpClients/IDataServiceApiClient.cs
@@ -5,7 +5,7 @@ namespace Portal.HttpClients
 {
     public interface IDataServiceApiClient
     {
-        Task PutAssessmentCompleted(int sdocId, string comment);
+        Task MarkAssessmentAsCompleted(int sdocId, string comment);
         Task<DocumentAssessmentData> GetAssessmentData(int sdocId);
     }
 }

--- a/src/Portal/Portal/Pages/DbAssessment/Assess.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/Assess.cshtml.cs
@@ -516,22 +516,6 @@ namespace Portal.Pages.DbAssessment
             }
         }
 
-        private async Task UpdateSdraAssessmentAsCompleted(string comment, WorkflowInstance workflowInstance)
-        {
-            try
-            {
-                await _dataServiceApiClient.PutAssessmentCompleted(workflowInstance.AssessmentData.PrimarySdocId,
-                    comment);
-            }
-            catch (Exception e)
-            {
-                _logger.LogError(e, "Failed requesting DataService {DataServiceResource} with: PrimarySdocId: {PrimarySdocId}; Comment: {Comment};",
-                    nameof(_dataServiceApiClient.PutAssessmentCompleted),
-                    workflowInstance.AssessmentData.PrimarySdocId,
-                    comment);
-            }
-        }
-
         private async Task GetOnHoldData(int processId)
         {
             var onHoldRows = await _dbContext.OnHold.Where(r => r.ProcessId == processId).ToListAsync();

--- a/src/Portal/Portal/Pages/DbAssessment/Review.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/Review.cshtml.cs
@@ -342,12 +342,12 @@ namespace Portal.Pages.DbAssessment
         {
             try
             {
-                await _dataServiceApiClient.PutAssessmentCompleted(workflowInstance.AssessmentData.PrimarySdocId, comment);
+                await _dataServiceApiClient.MarkAssessmentAsCompleted(workflowInstance.AssessmentData.PrimarySdocId, comment);
             }
             catch (Exception e)
             {
                 _logger.LogError(e, "Failed requesting DataService {DataServiceResource} with: PrimarySdocId: {PrimarySdocId}; Comment: {Comment};",
-                    nameof(_dataServiceApiClient.PutAssessmentCompleted),
+                    nameof(_dataServiceApiClient.MarkAssessmentAsCompleted),
                     workflowInstance.AssessmentData.PrimarySdocId,
                     comment);
             }

--- a/src/Portal/Portal/Pages/DbAssessment/Verify.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/Verify.cshtml.cs
@@ -554,23 +554,6 @@ namespace Portal.Pages.DbAssessment
             }
         }
 
-        private async Task UpdateSdraAssessmentAsCompleted(string comment, WorkflowInstance workflowInstance)
-        {
-            // TODO: Mark SDRA Assessment as completed
-            try
-            {
-                await _dataServiceApiClient.PutAssessmentCompleted(workflowInstance.AssessmentData.PrimarySdocId,
-                    comment);
-            }
-            catch (Exception e)
-            {
-                _logger.LogError(e, "Failed requesting DataService {DataServiceResource} with: PrimarySdocId: {PrimarySdocId}; Comment: {Comment};",
-                    nameof(_dataServiceApiClient.PutAssessmentCompleted),
-                    workflowInstance.AssessmentData.PrimarySdocId,
-                    comment);
-            }
-        }
-
         private async Task GetOnHoldData(int processId)
         {
             var onHoldRows = await _dbContext.OnHold.Where(r => r.ProcessId == processId).ToListAsync();

--- a/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml
+++ b/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml
@@ -37,7 +37,7 @@
                         </td>
                         <td>
                             @{
-                                if (Model.PrimaryDocumentStatus != null && Model.PrimaryDocumentStatus.Status == SourceDocumentRetrievalStatus.Complete.ToString())
+                                if (Model.PrimaryDocumentStatus != null && Model.PrimaryDocumentStatus.Status == SourceDocumentRetrievalStatus.FileGenerated.ToString())
                                 {
                                     <a href="@Model.PrimaryDocumentContentServiceUri" target="_blank">@Model.Assessment.ParsedRsdraNumber</a>
                                 }

--- a/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml
+++ b/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml
@@ -97,7 +97,7 @@
                                 </td>
                                 <td>
                                     @{
-                                        if (attachedLinkedDocument.Status.Equals(LinkedDocumentRetrievalStatus.Complete.ToString(), StringComparison.OrdinalIgnoreCase))
+                                        if (attachedLinkedDocument.Status.Equals(LinkedDocumentRetrievalStatus.FileGenerated.ToString(), StringComparison.OrdinalIgnoreCase))
                                         {
                                             <a href="@attachedLinkedDocument.ContentServiceUri" target="_blank">@attachedLinkedDocument.ParsedRsdraNumber</a>
                                         }
@@ -129,7 +129,7 @@
                                 <td>@databaseDocument.SdocId</td>
                                 <td>
                                     @{
-                                        if (databaseDocument.Status.Equals(LinkedDocumentRetrievalStatus.Complete.ToString(), StringComparison.OrdinalIgnoreCase))
+                                        if (databaseDocument.Status.Equals(LinkedDocumentRetrievalStatus.FileGenerated.ToString(), StringComparison.OrdinalIgnoreCase))
                                         {
                                             <a href="@databaseDocument.ContentServiceUri" target="_blank"></a>
                                         }

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Handlers/ClearDocumentRequestFromQueueCommandHandler.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Handlers/ClearDocumentRequestFromQueueCommandHandler.cs
@@ -47,7 +47,7 @@ namespace SourceDocumentCoordinator.Handlers
                                                     _documentStatusFactory, 
                                                     message.ProcessId, 
                                                     message.SourceDocumentId, null, null, 
-                                                    SourceDocumentRetrievalStatus.Complete, 
+                                                    SourceDocumentRetrievalStatus.FileGenerated, 
                                                     message.SourceType, message.CorrelationId);
                         break;
                     default:

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Config/UriConfig.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Config/UriConfig.cs
@@ -17,11 +17,20 @@ namespace WorkflowCoordinator.Config
         public Uri K2WebServiceGetTasksUri { get; set; }
         public Uri DataServicesLocalhostHealthcheckUrl { get; set; }
         public Uri DataServicesHealthcheckUrl { get; set; }
-
+        public string DataServicesWebServiceAssessmentCompletedUri { get; set; }
+        
         public Uri BuildDataServicesUri(string callerCode, int sdocId)
         {
             return sdocId == 0 ? new Uri(ConfigHelpers.IsLocalDevelopment ? DataAccessLocalhostBaseUri : DataServicesWebServiceBaseUri, $@"{DataServicesWebServiceDocumentsForAssessmentUri}{callerCode}") : 
                 new Uri(ConfigHelpers.IsLocalDevelopment ? DataAccessLocalhostBaseUri : DataServicesWebServiceBaseUri, $@"{DataServicesDocumentAssessmentDataUri}{sdocId}");
         }
+
+        public Uri BuildDataServicesCompleteAssessmentUri(string callerCode, int sdocId, string comment)
+        {
+            return new Uri(
+                ConfigHelpers.IsLocalDevelopment ? DataAccessLocalhostBaseUri : DataServicesWebServiceBaseUri,
+                $@"{DataServicesWebServiceAssessmentCompletedUri}{callerCode}/{sdocId}?comment={Uri.EscapeDataString(comment)}");
+        }
+
     }
 }

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Config/UriConfig.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Config/UriConfig.cs
@@ -18,18 +18,30 @@ namespace WorkflowCoordinator.Config
         public Uri DataServicesLocalhostHealthcheckUrl { get; set; }
         public Uri DataServicesHealthcheckUrl { get; set; }
         public string DataServicesWebServiceAssessmentCompletedUri { get; set; }
-        
+        public string DataServicesWebServiceAssessmentAssessedUri { get; set; }
+
         public Uri BuildDataServicesUri(string callerCode, int sdocId)
         {
             return sdocId == 0 ? new Uri(ConfigHelpers.IsLocalDevelopment ? DataAccessLocalhostBaseUri : DataServicesWebServiceBaseUri, $@"{DataServicesWebServiceDocumentsForAssessmentUri}{callerCode}") : 
                 new Uri(ConfigHelpers.IsLocalDevelopment ? DataAccessLocalhostBaseUri : DataServicesWebServiceBaseUri, $@"{DataServicesDocumentAssessmentDataUri}{sdocId}");
         }
 
-        public Uri BuildDataServicesCompleteAssessmentUri(string callerCode, int sdocId, string comment)
+        public Uri BuildDataServicesMarkAssessmentCompletedUri(string callerCode, int sdocId, string comment)
         {
             return new Uri(
                 ConfigHelpers.IsLocalDevelopment ? DataAccessLocalhostBaseUri : DataServicesWebServiceBaseUri,
                 $@"{DataServicesWebServiceAssessmentCompletedUri}{callerCode}/{sdocId}?comment={Uri.EscapeDataString(comment)}");
+        }
+
+        public Uri BuildDataServicesMarkAssessmentAssessedUri(string callerCode,
+                                                                string transactionId,
+                                                                int? sdocId,
+                                                                string actionType,
+                                                                string change)
+        {
+            return new Uri(
+                ConfigHelpers.IsLocalDevelopment ? DataAccessLocalhostBaseUri : DataServicesWebServiceBaseUri,
+                $@"{DataServicesWebServiceAssessmentAssessedUri}{callerCode}/{transactionId}/{sdocId}/{actionType}/{change}");
         }
 
     }

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Handlers/CompleteAssessmentCommandHandler.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Handlers/CompleteAssessmentCommandHandler.cs
@@ -1,21 +1,29 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Common.Helpers;
 using Microsoft.Extensions.Logging;
 using NServiceBus;
 using Serilog.Context;
+using WorkflowCoordinator.HttpClients;
 using WorkflowCoordinator.Messages;
 using WorkflowDatabase.EF;
+using WorkflowDatabase.EF.Models;
 
 namespace WorkflowCoordinator.Handlers
 {
     public class CompleteAssessmentCommandHandler : IHandleMessages<CompleteAssessmentCommand>
     {
         private readonly ILogger<CompleteAssessmentCommandHandler> _logger;
+        private readonly IDataServiceApiClient _dataServiceApiClient;
         private readonly WorkflowDbContext _dbContext;
 
-        public CompleteAssessmentCommandHandler(ILogger<CompleteAssessmentCommandHandler> logger, WorkflowDbContext dbContext)
+        public CompleteAssessmentCommandHandler(
+                                                ILogger<CompleteAssessmentCommandHandler> logger,
+                                                IDataServiceApiClient dataServiceApiClient,
+                                                WorkflowDbContext dbContext)
         {
             _logger = logger;
+            _dataServiceApiClient = dataServiceApiClient;
             _dbContext = dbContext;
         }
 
@@ -29,6 +37,23 @@ namespace WorkflowCoordinator.Handlers
 
             _logger.LogInformation("Entering {EventName} handler with: {Message}");
 
+        }
+
+        private async Task UpdateSdraAssessmentAsCompleted(string comment, WorkflowInstance workflowInstance)
+        {
+            // TODO: Mark SDRA Assessment as Assessed first, then mark as completed
+            try
+            {
+                await _dataServiceApiClient.MarkAssessmentAsCompleted(workflowInstance.AssessmentData.PrimarySdocId,
+                    comment);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Failed requesting DataService {DataServiceResource} with: PrimarySdocId: {PrimarySdocId}; Comment: {Comment};",
+                    nameof(_dataServiceApiClient.MarkAssessmentAsCompleted),
+                    workflowInstance.AssessmentData.PrimarySdocId,
+                    comment);
+            }
         }
     }
 }

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Handlers/CompleteAssessmentCommandHandler.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Handlers/CompleteAssessmentCommandHandler.cs
@@ -58,10 +58,12 @@ namespace WorkflowCoordinator.Handlers
                     ? "Imm Act - NM"
                     : "Longer-term Action";
 
+            LogContext.PushProperty("SdocId", sdocId);
+
             if (workflowInstance.PrimaryDocumentStatus.Status == SourceDocumentRetrievalStatus.Completed.ToString())
             {
                 // Already marked as Completed
-                _logger.LogInformation("SDRA Job with SdocId {sdocId}, belongs to ProcessId {ProcessId}, is already marked as Completed.", sdocId);
+                _logger.LogInformation("SDRA Job with SdocId {SdocId}, belongs to ProcessId {ProcessId}, is already marked as Completed.");
 
                 return;
             }
@@ -77,7 +79,7 @@ namespace WorkflowCoordinator.Handlers
 
         private async Task UpdateSdraAssessmentAsAssessed(int sdocId, int processId, string action)
         {
-            _logger.LogInformation("Marking PrimarySdocIds {SdocId}s as Assessed, triggered by ProcessId {ProcessId}", sdocId);
+            _logger.LogInformation("Marking PrimarySdocIds {SdocId} as Assessed, triggered by ProcessId {ProcessId}");
             
             try
             {
@@ -89,7 +91,7 @@ namespace WorkflowCoordinator.Handlers
 
                 await _dbContext.SaveChangesAsync();
 
-                _logger.LogInformation("Successfully Marked PrimarySdocIds {SdocId} as Assessed, triggered by ProcessId {ProcessId}", sdocId);
+                _logger.LogInformation("Successfully Marked PrimarySdocIds {SdocId} as Assessed, triggered by ProcessId {ProcessId}");
 
             }
             catch (Exception e)
@@ -104,7 +106,7 @@ namespace WorkflowCoordinator.Handlers
 
         private async Task UpdateSdraAssessmentAsCompleted(int sdocId)
         {
-            _logger.LogInformation("Marking PrimarySdocIds {SdocId}s as Completed, triggered by ProcessId {ProcessId}", sdocId);
+            _logger.LogInformation("Marking PrimarySdocIds {SdocId} as Completed, triggered by ProcessId {ProcessId}");
 
             try
             {
@@ -116,7 +118,7 @@ namespace WorkflowCoordinator.Handlers
 
                 await _dbContext.SaveChangesAsync();
 
-                _logger.LogInformation("Successfully Marked PrimarySdocIds {SdocId} as Completed, triggered by ProcessId {ProcessId}", sdocId);
+                _logger.LogInformation("Successfully Marked PrimarySdocIds {SdocId} as Completed, triggered by ProcessId {ProcessId}");
 
             }
             catch (Exception e)

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Handlers/CompleteAssessmentCommandHandler.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Handlers/CompleteAssessmentCommandHandler.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Common.Helpers;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NServiceBus;
 using Serilog.Context;
@@ -37,21 +39,55 @@ namespace WorkflowCoordinator.Handlers
 
             _logger.LogInformation("Entering {EventName} handler with: {Message}");
 
+            var workflowInstance = await _dbContext.WorkflowInstance
+                .Include(wi => wi.AssessmentData)
+                .Include(wi => wi.DbAssessmentVerifyData)
+                .FirstOrDefaultAsync(wi => wi.ProcessId == message.ProcessId);
+
+            var action =
+                workflowInstance.DbAssessmentVerifyData.TaskType.Equals("Simple",
+                    StringComparison.InvariantCultureIgnoreCase)
+                    ? "Imm Act - NM"
+                    : "Longer-term Action";
+            var sdocId = workflowInstance.AssessmentData.PrimarySdocId;
+
+            // TODO: Mark SDRA Assessment as Assessed first, then mark as completed
+
+            await UpdateSdraAssessmentAsAssessed(sdocId, message.ProcessId, action);
+            await UpdateSdraAssessmentAsCompleted(sdocId, action);
         }
 
-        private async Task UpdateSdraAssessmentAsCompleted(string comment, WorkflowInstance workflowInstance)
+        private async Task UpdateSdraAssessmentAsAssessed(int sdocId, int processId, string action)
+        {
+            // TODO: Mark SDRA Assessment as Assessed first, then mark as completed
+
+
+            try
+            {
+                //await _dataServiceApiClient.MarkAssessmentAsCompleted(workflowInstance.AssessmentData.PrimarySdocId,
+                //    comment);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e,
+                    "Failed requesting DataService {DataServiceResource} with: PrimarySdocId: {PrimarySdocId}",
+                    nameof(_dataServiceApiClient.MarkAssessmentAsCompleted),
+                    sdocId);
+            }
+        }
+
+        private async Task UpdateSdraAssessmentAsCompleted(int sdocId, string comment)
         {
             // TODO: Mark SDRA Assessment as Assessed first, then mark as completed
             try
             {
-                await _dataServiceApiClient.MarkAssessmentAsCompleted(workflowInstance.AssessmentData.PrimarySdocId,
-                    comment);
+                await _dataServiceApiClient.MarkAssessmentAsCompleted(sdocId, comment);
             }
             catch (Exception e)
             {
                 _logger.LogError(e, "Failed requesting DataService {DataServiceResource} with: PrimarySdocId: {PrimarySdocId}; Comment: {Comment};",
                     nameof(_dataServiceApiClient.MarkAssessmentAsCompleted),
-                    workflowInstance.AssessmentData.PrimarySdocId,
+                    sdocId,
                     comment);
             }
         }

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Handlers/CompleteAssessmentCommandHandler.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Handlers/CompleteAssessmentCommandHandler.cs
@@ -61,11 +61,9 @@ namespace WorkflowCoordinator.Handlers
         {
             // TODO: Mark SDRA Assessment as Assessed first, then mark as completed
 
-
             try
             {
-                //await _dataServiceApiClient.MarkAssessmentAsCompleted(workflowInstance.AssessmentData.PrimarySdocId,
-                //    comment);
+                await _dataServiceApiClient.MarkAssessmentAsAssessed(processId.ToString(), sdocId, action, "");
             }
             catch (Exception e)
             {

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Handlers/CompleteAssessmentCommandHandler.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Handlers/CompleteAssessmentCommandHandler.cs
@@ -1,0 +1,34 @@
+﻿using System.Threading.Tasks;
+using Common.Helpers;
+using Microsoft.Extensions.Logging;
+using NServiceBus;
+using Serilog.Context;
+using WorkflowCoordinator.Messages;
+using WorkflowDatabase.EF;
+
+namespace WorkflowCoordinator.Handlers
+{
+    public class CompleteAssessmentCommandHandler : IHandleMessages<CompleteAssessmentCommand>
+    {
+        private readonly ILogger<CompleteAssessmentCommandHandler> _logger;
+        private readonly WorkflowDbContext _dbContext;
+
+        public CompleteAssessmentCommandHandler(ILogger<CompleteAssessmentCommandHandler> logger, WorkflowDbContext dbContext)
+        {
+            _logger = logger;
+            _dbContext = dbContext;
+        }
+
+        public async Task Handle(CompleteAssessmentCommand message, IMessageHandlerContext context)
+        {
+            LogContext.PushProperty("MessageId", context.MessageId);
+            LogContext.PushProperty("Message", message.ToJSONSerializedString());
+            LogContext.PushProperty("EventName", nameof(CompleteAssessmentCommand));
+            LogContext.PushProperty("MessageCorrelationId", message.CorrelationId);
+            LogContext.PushProperty("ProcessId", message.ProcessId);
+
+            _logger.LogInformation("Entering {EventName} handler with: {Message}");
+
+        }
+    }
+}

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Handlers/PersistWorkflowInstanceDataEventHandler.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Handlers/PersistWorkflowInstanceDataEventHandler.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using NServiceBus;
 using Serilog.Context;
 using WorkflowCoordinator.HttpClients;
+using WorkflowCoordinator.Messages;
 using WorkflowCoordinator.Models;
 using WorkflowDatabase.EF;
 using WorkflowDatabase.EF.Models;
@@ -78,8 +79,15 @@ namespace WorkflowCoordinator.Handlers
 
                     await UpdateWorkflowInstanceData(message.ProcessId, message.ToActivity, k2Task);
 
-                    // Fire new CompleteAssessmentCommand: CorrelationId, processId
+                    // Fire CompleteAssessmentCommand to mark SDRA Assessment as completed
+                    var completeAssessment = new CompleteAssessmentCommand
+                    {
+                        CorrelationId = message.CorrelationId,
+                        ProcessId = message.ProcessId
+                    };
 
+                    await context.SendLocal(completeAssessment).ConfigureAwait(false);
+                    
                     _logger.LogInformation("Task with processId: {ProcessId} has been completed.");
 
                     break;

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Handlers/PersistWorkflowInstanceDataEventHandler.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Handlers/PersistWorkflowInstanceDataEventHandler.cs
@@ -78,6 +78,8 @@ namespace WorkflowCoordinator.Handlers
 
                     await UpdateWorkflowInstanceData(message.ProcessId, message.ToActivity, k2Task);
 
+                    // Fire new CompleteAssessmentCommand: CorrelationId, processId
+
                     _logger.LogInformation("Task with processId: {ProcessId} has been completed.");
 
                     break;

--- a/src/WorkflowCoordinator/WorkflowCoordinator/HttpClients/DataServiceApiClient.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/HttpClients/DataServiceApiClient.cs
@@ -66,6 +66,22 @@ namespace WorkflowCoordinator.HttpClients
             return assessmentData;
         }
 
+        public async Task MarkAssessmentAsCompleted(int sdocId, string comment)
+        {
+            var data = "";
+            var fullUri = _uriConfig.Value.BuildDataServicesCompleteAssessmentUri(_generalConfig.Value.CallerCode, sdocId, comment);
+
+            using (var response = await _httpClient.PutAsync(fullUri.ToString(), null).ConfigureAwait(false))
+            {
+                data = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (!response.IsSuccessStatusCode)
+                    throw new ApplicationException($"StatusCode='{response.StatusCode}'," +
+                                                   $"\n Message= '{data}'," +
+                                                   $"\n Url='{fullUri}'");
+            }
+        }
+
+
         public async Task<bool> CheckDataServicesConnection()
         {
             var fullUri = new Uri(ConfigHelpers.IsLocalDevelopment ? $"{_uriConfig.Value.DataServicesLocalhostHealthcheckUrl}" :

--- a/src/WorkflowCoordinator/WorkflowCoordinator/HttpClients/DataServiceApiClient.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/HttpClients/DataServiceApiClient.cs
@@ -75,9 +75,17 @@ namespace WorkflowCoordinator.HttpClients
             {
                 data = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 if (!response.IsSuccessStatusCode)
+                {
+                    if (data.Contains("not being assessed by HDB", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        // Treat this error as sdoc-id is already assessed and completed
+                        return;
+                    }
+
                     throw new ApplicationException($"StatusCode='{response.StatusCode}'," +
                                                    $"\n Message= '{data}'," +
                                                    $"\n Url='{fullUri}'");
+                }
             }
         }
 
@@ -92,10 +100,18 @@ namespace WorkflowCoordinator.HttpClients
             using (var response = await _httpClient.PutAsync(fullUri.ToString(), null).ConfigureAwait(false))
             {
                 data = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
                 if (!response.IsSuccessStatusCode)
+                {
+                    if (data.Contains("not being assessed by HDB", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        // Treat this error as sdoc-id is already assessed and completed
+                        return;
+                    }
+
                     throw new ApplicationException($"StatusCode='{response.StatusCode}'," +
                                                    $"\n Message= '{data}'," +
-                                                   $"\n Url='{fullUri}'");
+                                                   $"\n Url='{fullUri}'"); }
             }
         }
 

--- a/src/WorkflowCoordinator/WorkflowCoordinator/HttpClients/DataServiceApiClient.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/HttpClients/DataServiceApiClient.cs
@@ -69,7 +69,7 @@ namespace WorkflowCoordinator.HttpClients
         public async Task MarkAssessmentAsCompleted(int sdocId, string comment)
         {
             var data = "";
-            var fullUri = _uriConfig.Value.BuildDataServicesCompleteAssessmentUri(_generalConfig.Value.CallerCode, sdocId, comment);
+            var fullUri = _uriConfig.Value.BuildDataServicesMarkAssessmentCompletedUri(_generalConfig.Value.CallerCode, sdocId, comment);
 
             using (var response = await _httpClient.PutAsync(fullUri.ToString(), null).ConfigureAwait(false))
             {
@@ -81,6 +81,23 @@ namespace WorkflowCoordinator.HttpClients
             }
         }
 
+        public async Task MarkAssessmentAsAssessed(string transactionId,
+                                                    int sdocId,
+                                                    string actionType,
+                                                    string change)
+        {
+            var data = "";
+            var fullUri = _uriConfig.Value.BuildDataServicesMarkAssessmentAssessedUri(_generalConfig.Value.CallerCode, transactionId, sdocId, actionType, change);
+
+            using (var response = await _httpClient.PutAsync(fullUri.ToString(), null).ConfigureAwait(false))
+            {
+                data = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (!response.IsSuccessStatusCode)
+                    throw new ApplicationException($"StatusCode='{response.StatusCode}'," +
+                                                   $"\n Message= '{data}'," +
+                                                   $"\n Url='{fullUri}'");
+            }
+        }
 
         public async Task<bool> CheckDataServicesConnection()
         {

--- a/src/WorkflowCoordinator/WorkflowCoordinator/HttpClients/IDataServiceApiClient.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/HttpClients/IDataServiceApiClient.cs
@@ -9,6 +9,7 @@ namespace WorkflowCoordinator.HttpClients
         Task<IEnumerable<DocumentObject>> GetAssessments(string callerCode);
         Task<DocumentAssessmentData> GetAssessmentData(string callerCode, int sdocId);
         Task MarkAssessmentAsCompleted(int sdocId, string comment);
+        Task MarkAssessmentAsAssessed(string transactionId, int sdocId, string actionType, string change);
 
         Task<bool> CheckDataServicesConnection();
     }

--- a/src/WorkflowCoordinator/WorkflowCoordinator/HttpClients/IDataServiceApiClient.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/HttpClients/IDataServiceApiClient.cs
@@ -8,6 +8,8 @@ namespace WorkflowCoordinator.HttpClients
     {
         Task<IEnumerable<DocumentObject>> GetAssessments(string callerCode);
         Task<DocumentAssessmentData> GetAssessmentData(string callerCode, int sdocId);
+        Task MarkAssessmentAsCompleted(int sdocId, string comment);
+
         Task<bool> CheckDataServicesConnection();
     }
 }

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Messages/CompleteAssessmentCommand.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Messages/CompleteAssessmentCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System;
+using Common.Messages;
 
-namespace Common.Messages.Commands
+namespace WorkflowCoordinator.Messages
 {
     public class CompleteAssessmentCommand : ICorrelate
     {


### PR DESCRIPTION
1. Added call to SDRA-Api's NotifyDocumentAssessedAsync
2. Renamed Status 'Complete', in SourceDocumentRetrievalStatus and LinkedDocumentRetrievalStatus, to FileGenerated
3. Added two new statuses, to SourceDocumentRetrievalStatus and LinkedDocumentRetrievalStatus, 'Assessed' and 'Completed'
4. Added Azure uri configurations for DataServicesWebServiceAssessmentCompletedUri and DataServicesWebServiceAssessmentAssessedUri 
5. Removed un-used code in Review, Assess, and Verify for calling SDRA-api to mark sdocid as Completed
6. Added new command CompleteAssessmentCommand; fired when persisting Verify Sign-off
7. Added new message handler CompleteAssessmentCommandHandler.cs
