### PR TITLE
Display build no and GitHub commit links on footer of NCNE

### DIFF
--- a/ncne-portal-azure-pipelines.yml
+++ b/ncne-portal-azure-pipelines.yml
@@ -41,32 +41,25 @@ stages:
           packageType: sdk
           version: 3.1.x
           installationPath: $(Agent.ToolsDirectory)\\dotnet
-          
-      - task: DotNetCoreCLI@2
-        inputs:
-          command: 'restore'
-          projects: '$(Build.SourcesDirectory)\\src\\ncneportal\\ncneportal.csproj'
-          feedsToUse: 'select'
-        displayName: 'dotnet restore ncneportal'
     
       - task: DotNetCoreCLI@2
         inputs:
           command: 'build'
           projects: '$(Build.SourcesDirectory)\\src\\ncneportal\\ncneportal.csproj'
+          arguments: '/p:SourceRevisionId=$(Build.SourceVersion)'
         displayName: 'dotnet build ncneportal'
-  
-      - task: DotNetCoreCLI@2
-        inputs:
-          command: 'restore'
-          projects: '$(Build.SourcesDirectory)\\src\\NCNEPortal.UnitTests\\ncneportal.unittests.csproj'
-          feedsToUse: 'select'
-        displayName: 'dotnet restore ncneportal tests'
   
       - task: DotNetCoreCLI@2
         inputs:
           command: 'build'
           projects: '$(Build.SourcesDirectory)\\src\\NCNEPortal.UnitTests\\ncneportal.unittests.csproj'
         displayName: 'dotnet build ncneportal tests'
+
+      # Write build number and Id to text file
+      - script: '(echo $(Build.BuildNumber) && echo $(Build.BuildId)) > .buildinfo.json'
+        displayName: "Emit build number"
+        workingDirectory: '$(Build.SourcesDirectory)\\src\\ncneportal'
+        failOnStderr: true
   
       - task: DotNetCoreCLI@2
         inputs:
@@ -97,7 +90,7 @@ stages:
           publishWebProjects: false
           projects: '$(Build.SourcesDirectory)\\src\\ncneportal\\ncneportal.csproj'
           zipAfterPublish: false
-          arguments: '--output $(Build.ArtifactStagingDirectory)\\ncneportal'
+          arguments: '/p:SourceRevisionId=$(Build.SourceVersion) --output $(Build.ArtifactStagingDirectory)\\ncneportal'
         displayName: 'Publish ncneportal-project'
   
       - task: PublishBuildArtifacts@1

--- a/src/NCNEPortal.UnitTests/AppVersionInfoTests.cs
+++ b/src/NCNEPortal.UnitTests/AppVersionInfoTests.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Threading.Tasks;
+using FakeItEasy;
+using Microsoft.Extensions.Hosting;
+using NCNEPortal.Helpers;
+using NUnit.Framework;
+
+namespace NCNEPortal.UnitTests
+{
+    [TestFixture]
+    public class AppVersionInfoTests
+    {
+        public AppVersionInfo _appVersionInfo { get; set; }
+        public IHostEnvironment _hostEnvironment { get; set; }
+
+        [SetUp]
+        public void Setup()
+        {
+            _hostEnvironment = A.Fake<IHostEnvironment>();
+            _appVersionInfo = new AppVersionInfo(_hostEnvironment);
+        }
+
+        [Test]
+        public async Task Test_GitHash_set_To_LOCALBUILD_when_no_InformationalVersion_value_exists()
+        {
+            Assert.AreEqual("LOCALBUILD",_appVersionInfo.GitHash);
+        }
+
+        [Test]
+        public async Task Test_ShortGitHash_set_to_LBUILD_when_no_InformationalVersion_value_exists()
+        {
+            Assert.AreEqual("LBUILD", _appVersionInfo.ShortGitHash);
+        }
+
+        [Test]
+        public async Task Test_BuildId_set_to_123456_when_no_buildInfo_file_exists()
+        {
+            Assert.AreEqual("123456", _appVersionInfo.BuildId);
+        }
+
+        [Test]
+        public async Task Test_BuildNumber_set_to_today_when_no_buildInfo_file_exists()
+        {
+            var today = DateTime.UtcNow.ToString("yyyyMMdd") + ".0";
+            Assert.AreEqual(today, _appVersionInfo.BuildNumber);
+        }
+    }
+}

--- a/src/NCNEPortal.UnitTests/AppVersionInfoTests.cs
+++ b/src/NCNEPortal.UnitTests/AppVersionInfoTests.cs
@@ -33,13 +33,7 @@ namespace NCNEPortal.UnitTests
         }
 
         [Test]
-        public async Task Test_BuildId_set_to_123456_when_no_buildInfo_file_exists()
-        {
-            Assert.AreEqual("123456", _appVersionInfo.BuildId);
-        }
-
-        [Test]
-        public async Task Test_BuildNumber_set_to_today_when_no_buildInfo_file_exists()
+        public async Task Test_BuildNumber_set_to_today()
         {
             var today = DateTime.UtcNow.ToString("yyyyMMdd");
             StringAssert.Contains(today, _appVersionInfo.BuildNumber);

--- a/src/NCNEPortal.UnitTests/AppVersionInfoTests.cs
+++ b/src/NCNEPortal.UnitTests/AppVersionInfoTests.cs
@@ -41,8 +41,8 @@ namespace NCNEPortal.UnitTests
         [Test]
         public async Task Test_BuildNumber_set_to_today_when_no_buildInfo_file_exists()
         {
-            var today = DateTime.UtcNow.ToString("yyyyMMdd") + ".0";
-            Assert.AreEqual(today, _appVersionInfo.BuildNumber);
+            var today = DateTime.UtcNow.ToString("yyyyMMdd");
+            StringAssert.Contains(today, _appVersionInfo.BuildNumber);
         }
     }
 }

--- a/src/NCNEPortal/Helpers/AppVersionInfo.cs
+++ b/src/NCNEPortal/Helpers/AppVersionInfo.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Hosting;
 
-namespace Portal.Helpers
+namespace NCNEPortal.Helpers
 {
     public class AppVersionInfo
     {

--- a/src/NCNEPortal/NCNEPortal.csproj
+++ b/src/NCNEPortal/NCNEPortal.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <InformationalVersion></InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NCNEPortal/Pages/Shared/_Layout.cshtml
+++ b/src/NCNEPortal/Pages/Shared/_Layout.cshtml
@@ -1,4 +1,7 @@
-﻿@{
+﻿@using NCNEPortal.Helpers
+@inject AppVersionInfo appInfo
+
+@{
     ViewData["Year"] = DateTime.Now.Year;
 }
 <!DOCTYPE html>
@@ -58,7 +61,15 @@
         <div class="container body-content flex-fill">
             @RenderBody()
         </div>
-        <footer>&copy; Crown copyright @ViewData["Year"] UK Hydrographic Office</footer>
+        <footer>
+            <div class="row">
+                <div class="col-4 justify-content-start">&copy; Crown copyright @ViewData["Year"] UK Hydrographic Office</div>
+                <div class="col-8 versioning">
+                    Deployed from commit <a href="https://github.com/UKHO/taskmanager/commit/@appInfo.GitHash" target="_blank">@appInfo.ShortGitHash</a>
+                    via build <a href="https://ukhogov.visualstudio.com/Pipelines/_build/results?buildId=@appInfo.BuildId&view=results" target="_blank">@appInfo.BuildNumber</a>
+                </div>
+            </div>
+        </footer>
     </div>
 </body>
 </html>

--- a/src/NCNEPortal/Startup.cs
+++ b/src/NCNEPortal/Startup.cs
@@ -152,7 +152,6 @@ namespace NCNEPortal
                 }
             }
 
-
             var startupSecretConfig = new StartupSecretsConfig();
             Configuration.GetSection("K2RestApi").Bind(startupSecretConfig);
             Configuration.GetSection("HpdDbSection").Bind(startupSecretConfig);
@@ -163,6 +162,7 @@ namespace NCNEPortal
             services.AddDbContext<HpdDbContext>((serviceProvider, options) =>
                 options.UseOracle(hpdConnection));
 
+            services.AddSingleton<AppVersionInfo>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/NCNEPortal/wwwroot/css/site.css
+++ b/src/NCNEPortal/wwwroot/css/site.css
@@ -8,8 +8,6 @@ body {
     font-weight: 300;
 }
 
-
-
 /* Start chevron for notes on landing page */
 table.dataTable td.details-control i:before {
     content: '\f078';
@@ -371,6 +369,11 @@ body, .sticky-footer-wrapper {
 
 .flex-fill {
     flex: 1 1 auto;
+}
+
+.versioning {
+    text-align: right;
+    font-size: 11px;
 }
 /* Footer end */
 

--- a/src/Portal/Portal/Helpers/AppVersionInfo.cs
+++ b/src/Portal/Portal/Helpers/AppVersionInfo.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.Hosting;
+
+namespace Portal.Helpers
+{
+    public class AppVersionInfo
+    {
+        private static readonly string _buildFileName = ".buildinfo.json";
+        private string _buildFilePath;
+        private string _buildNumber;
+        private string _buildId;
+        private string _gitHash;
+        private string _gitShortHash;
+
+        public AppVersionInfo(IHostEnvironment hostEnvironment)
+        {
+            _buildFilePath = Path.Combine(hostEnvironment.ContentRootPath, _buildFileName);
+        }
+
+        public string BuildNumber
+        {
+            get
+            {
+                // Build number format should be yyyyMMdd.# (e.g. 20200308.1)
+                if (string.IsNullOrEmpty(_buildNumber))
+                {
+                    if (File.Exists(_buildFilePath))
+                    {
+                        var fileContents = File.ReadLines(_buildFilePath).ToList();
+
+                        // First line is build number, second is build id
+                        if (fileContents.Count > 0)
+                        {
+                            _buildNumber = fileContents[0];
+                        }
+                        if (fileContents.Count > 1)
+                        {
+                            _buildId = fileContents[1];
+                        }
+                    }
+
+                    if (string.IsNullOrEmpty(_buildNumber))
+                    {
+                        _buildNumber = DateTime.UtcNow.ToString("yyyyMMdd") + ".0";
+                    }
+
+                    if (string.IsNullOrEmpty(_buildId))
+                    {
+                        _buildId = "123456";
+                    }
+                }
+
+                return _buildNumber;
+            }
+        }
+
+        public string BuildId
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_buildId))
+                {
+                    var _ = BuildNumber;
+                }
+
+                return _buildId;
+            }
+        }
+
+        public string GitHash
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_gitHash))
+                {
+                    var version = "1.0.0+LOCALBUILD"; // Dummy version for local dev
+                    var appAssembly = typeof(AppVersionInfo).Assembly;
+                    var infoVerAttr = (AssemblyInformationalVersionAttribute)appAssembly
+                        .GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute)).FirstOrDefault();
+
+                    if (infoVerAttr != null && infoVerAttr.InformationalVersion.Length > 6)
+                    {
+                        // Hash is embedded in the version after a '+' symbol, e.g. 1.0.0+a34a913742f8845d3da5309b7b17242222d41a21
+                        version = infoVerAttr.InformationalVersion;
+                    }
+                    _gitHash = version.Substring(version.IndexOf('+') + 1);
+
+                }
+
+                return _gitHash;
+            }
+        }
+
+        public string ShortGitHash
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_gitShortHash))
+                {
+                    _gitShortHash = GitHash.Substring(GitHash.Length - 6, 6);
+                }
+                return _gitShortHash;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Remove not needed restore steps from NCNE YAML
- Pass $(Build.SourceVersion) into the dotnet build and publish commands, this will populate the new assembly InformationalVersion attribute in the csproj
- Add step to YAML to use a Bash script to write build number into json file
- Add AppVersionInfo helper class to construct build no and GitHub commit values
- Format _Layout.cshtml to display build no and GitHub commit as links
- Add unit tests for AppVersionInfo class


