### PR TITLE
Features/fix bug launch source editor button

### DIFF
--- a/src/Portal/Portal/Pages/DbAssessment/_EditDatabase.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_EditDatabase.cshtml.cs
@@ -398,8 +398,8 @@ namespace Portal.Pages.DbAssessment
                     ProjectName = _carisProjectNameGenerator.Generate(processId, parsedRsdraNumber, sourceDocumentName);
                     return;
                 }
-
-                ProjectName = "NO PROJECT HAS BEEN CREATED";
+                
+                ProjectName = "NO PROJECT HAS BEEN CREATED"; //TODO: Check with Matt for desired wording.
                 return;
             }
 

--- a/src/Portal/Portal/Pages/DbAssessment/_EditDatabase.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_EditDatabase.cshtml.cs
@@ -93,7 +93,7 @@ namespace Portal.Pages.DbAssessment
 
             await GetCarisData(processId, taskStage);
 
-            await GetCarisProjectDetails(processId);
+            await GetCarisProjectDetails(processId, taskStage);
 
             CarisProjectNameCharacterLimit = _generalConfig.Value.CarisProjectNameCharacterLimit;
             SessionFilename = _generalConfig.Value.SessionFilename;
@@ -380,7 +380,7 @@ namespace Portal.Pages.DbAssessment
             }
         }
 
-        private async Task GetCarisProjectDetails(int processId)
+        private async Task GetCarisProjectDetails(int processId, string taskStage)
         {
             CarisProjectDetails = await _dbContext.CarisProjectDetails.FirstOrDefaultAsync(cp => cp.ProcessId == processId);
 
@@ -388,13 +388,18 @@ namespace Portal.Pages.DbAssessment
 
             if (!IsCarisProjectCreated)
             {
+                if (taskStage == "Assess")
+                {
+                    var assessmentData =
+                        await _dbContext.AssessmentData.SingleAsync(ad => ad.ProcessId == processId);
+                    var parsedRsdraNumber = assessmentData.ParsedRsdraNumber;
+                    var sourceDocumentName = assessmentData.SourceDocumentName;
 
-                var assessmentData =
-                    await _dbContext.AssessmentData.SingleAsync(ad => ad.ProcessId == processId);
-                var parsedRsdraNumber = assessmentData.ParsedRsdraNumber;
-                var sourceDocumentName = assessmentData.SourceDocumentName;
+                    ProjectName = _carisProjectNameGenerator.Generate(processId, parsedRsdraNumber, sourceDocumentName);
+                    return;
+                }
 
-                ProjectName = _carisProjectNameGenerator.Generate(processId, parsedRsdraNumber, sourceDocumentName);
+                ProjectName = "NO PROJECT HAS BEEN CREATED";
                 return;
             }
 

--- a/src/Portal/Portal/wwwroot/js/EditDatabase.js
+++ b/src/Portal/Portal/wwwroot/js/EditDatabase.js
@@ -12,7 +12,7 @@ function setControlState(enableCarisProject, enableLaunchSource) {
             .prop("disabled", false);
     }
     if (enableLaunchSource) {
-        $("#btnLaunchSourceEditorDownload").prop("disabled", false);
+        $("#btnOpenLaunchCarisSelectionModal").prop("disabled", false);
     }
 }
 

--- a/src/Portal/Portal/wwwroot/js/EditDatabase.js
+++ b/src/Portal/Portal/wwwroot/js/EditDatabase.js
@@ -34,20 +34,28 @@ function getEditDatabase() {
         data: {
             "processId": processId,
             "taskStage": pageIdentity
-        }, 
+        },
         success: function (result) {
             $("#editDatabase").html(result);
             initializeLaunchSourceEditorModal();
             createCarisProjectHandler();
             initialiseWorkspaceTypeahead();
 
-            if (pageIdentity === 'Verify') {
-                setControlState(false, true);
-            } else if ($("#IsCarisProjectCreated").val() === "True") {
-                setControlState(false, true);
-            } else {
-                setControlState(true, false);
+            if (pageIdentity === 'Assess') {
+                if ($("#IsCarisProjectCreated").val() === "True") {
+                    setControlState(false, true);
+                } else {
+                    setControlState(true, false);
+                }
             }
+            else if (pageIdentity === 'Verify') {
+                if ($("#IsCarisProjectCreated").val() === "True") {
+                    setControlState(false, true);
+                } else {
+                    setControlState(false, false);
+                }
+            }
+
         },
         error: function (error) {
 


### PR DESCRIPTION
### Portal - Fixing bug 161840

- Launch source editor button is now enabled after successfully creating a CARIS project on Edit Database at Assess
- Changed logic for enabling/disabling buttons based on current stage and whether or not a CARIS project has been created.
- Set CARIS project name field on Verify to be a reminder that a project has not been created if a CARIS project was not created at Assess for the task.