### PR TITLE
Attempt to fix NSB issue NSB endpoints become unresponsive

### DIFF
--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Config/NsbSecretsConfig.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Config/NsbSecretsConfig.cs
@@ -5,6 +5,5 @@
         public string NsbInitialCatalog { get; set; }
         public string NsbDataSource { get; set; }
         public string NsbDbConnectionString { get; set; }
-        public string AzureAccessToken { get; set; }
     }
 }

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Program.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Program.cs
@@ -147,8 +147,6 @@ namespace SourceDocumentCoordinator
                     endpointConfiguration = new SourceDocumentCoordinatorConfig(nsbConfig, nsbSecretsConfig, (AzureServiceTokenProvider)azureServiceTokenProvider);
                 }
 
-
-
                 var serilogTracing = endpointConfiguration.EnableSerilogTracing(Log.Logger);
                 serilogTracing.EnableSagaTracing();
                 serilogTracing.EnableMessageTracing();
@@ -157,24 +155,22 @@ namespace SourceDocumentCoordinator
             })
             .UseConsoleLifetime();
 
+            IHost host = null;
 
-            var host = builder.Build();
-
-            var cancellationToken = new WebJobsShutdownWatcher().Token;
-            using (host)
+            try
             {
-                try
-                {
-                    await host.RunAsync(cancellationToken);
-                }
-                catch (Exception ex)
-                {
-                    Log.Fatal(ex, "Host terminated unexpectedly");
-                }
-                finally
-                {
-                    Log.CloseAndFlush();
-                }
+                host = builder.Build();
+                var cancellationToken = new WebJobsShutdownWatcher().Token;
+                await host.RunAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex, "Host terminated unexpectedly");
+            }
+            finally
+            {
+                Log.CloseAndFlush();
+                host?.Dispose();
             }
         }
     }

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Program.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Program.cs
@@ -6,6 +6,7 @@ using Common.Factories;
 using Common.Factories.Interfaces;
 using Common.Helpers;
 using Microsoft.Azure.Services.AppAuthentication;
+using Microsoft.Azure.WebJobs;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.AzureKeyVault;
@@ -145,11 +146,12 @@ namespace SourceDocumentCoordinator
 
             var host = builder.Build();
 
+            var cancellationToken = new WebJobsShutdownWatcher().Token;
             using (host)
             {
                 try
                 {
-                    await host.RunAsync();
+                    await host.RunAsync(cancellationToken);
                 }
                 catch (Exception ex)
                 {

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/SourceDocumentCoordinatorConfig.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/SourceDocumentCoordinatorConfig.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Data.SqlClient;
+using System.Diagnostics;
+using System.Threading.Tasks;
 using Common.Messages.Events;
+using Microsoft.Azure.Services.AppAuthentication;
 using NServiceBus;
 using NServiceBus.Persistence.Sql;
 using NServiceBus.Transport.SQLServer;
@@ -11,7 +14,7 @@ namespace SourceDocumentCoordinator
     public class SourceDocumentCoordinatorConfig : EndpointConfiguration
     {
         public SourceDocumentCoordinatorConfig(NsbConfig nsbConfig,
-            NsbSecretsConfig nsbSecretsConfig) : base(nsbConfig.SourceDocumentCoordinatorName)
+            NsbSecretsConfig nsbSecretsConfig, AzureServiceTokenProvider azureServiceTokenProvider = null) : base(nsbConfig.SourceDocumentCoordinatorName)
         {
             // Transport
 
@@ -23,7 +26,10 @@ namespace SourceDocumentCoordinator
                         try
                         {
                             con.ConnectionString = nsbSecretsConfig.NsbDbConnectionString;
-                            if (!nsbConfig.IsLocalDevelopment) con.AccessToken = nsbSecretsConfig.AzureAccessToken;
+                            if (!nsbConfig.IsLocalDevelopment && azureServiceTokenProvider != null)
+                            {
+                                con.AccessToken = await azureServiceTokenProvider.GetAccessTokenAsync(nsbConfig.AzureDbTokenUrl.ToString());
+                            }
                             await con.OpenAsync().ConfigureAwait(false);
                             return con;
                         }
@@ -56,7 +62,7 @@ namespace SourceDocumentCoordinator
                 try
                 {
                     con.ConnectionString = nsbSecretsConfig.NsbDbConnectionString;
-                    if (!nsbConfig.IsLocalDevelopment) con.AccessToken = nsbSecretsConfig.AzureAccessToken;
+                    if (!nsbConfig.IsLocalDevelopment) con.AccessToken = azureServiceTokenProvider.GetAccessTokenAsync(nsbConfig.AzureDbTokenUrl.ToString()).Result;
                     return con;
                 }
                 catch
@@ -81,6 +87,7 @@ namespace SourceDocumentCoordinator
             this.AssemblyScanner().ScanAssembliesInNestedDirectories = true;
             this.EnableInstallers();
             this.UseSerialization<NewtonsoftSerializer>();
+            this.DefineCriticalErrorAction(OnCriticalError);
 
             // Additional config for local development
 
@@ -100,5 +107,24 @@ namespace SourceDocumentCoordinator
                     });
             }
         }
+
+        #region WebJobHost_CriticalError
+        // Need to collect Application Events in Azure to see this
+        static async Task OnCriticalError(ICriticalErrorContext context)
+        {
+            var fatalMessage =
+                $"The following critical error was encountered:{Environment.NewLine}{context.Error}{Environment.NewLine}Process is shutting down. StackTrace: {Environment.NewLine}{context.Exception.StackTrace}";
+            EventLog.WriteEntry(".NET Runtime", fatalMessage, EventLogEntryType.Error);
+
+            try
+            {
+                await context.Stop().ConfigureAwait(false);
+            }
+            finally
+            {
+                Environment.FailFast(fatalMessage, context.Exception);
+            }
+        }
+        #endregion
     }
 }

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Config/NsbSecretsConfig.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Config/NsbSecretsConfig.cs
@@ -5,6 +5,5 @@
         public string NsbInitialCatalog { get; set; }
         public string NsbDataSource { get; set; }
         public string NsbDbConnectionString { get; set; }
-        public string AzureAccessToken { get; set; }
     }
 }

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Program.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Program.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using AutoMapper;
 using Common.Helpers;
 using Microsoft.Azure.Services.AppAuthentication;
+using Microsoft.Azure.WebJobs;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.AzureKeyVault;
@@ -161,11 +162,13 @@ namespace WorkflowCoordinator
 
             var host = builder.Build();
 
+            var cancellationToken = new WebJobsShutdownWatcher().Token;
+
             using (host)
             {
                 try
                 {
-                    await host.WorkflowCoordinatorRunAsync();
+                    await host.WorkflowCoordinatorRunAsync(cancellationToken);
                 }
                 catch (Exception ex)
                 {

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Program.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Program.cs
@@ -159,6 +159,7 @@ namespace WorkflowCoordinator
                         endpointConfiguration = new WorkflowCoordinatorConfig(nsbConfig, nsbSecretsConfig, (AzureServiceTokenProvider)azureServiceTokenProvider);
                     }
 
+
                     var serilogTracing = endpointConfiguration.EnableSerilogTracing(Log.Logger);
                     serilogTracing.EnableSagaTracing();
                     serilogTracing.EnableMessageTracing();
@@ -167,24 +168,22 @@ namespace WorkflowCoordinator
                 })
                 .UseConsoleLifetime();
 
-            var host = builder.Build();
+            IHost host = null;
 
-            var cancellationToken = new WebJobsShutdownWatcher().Token;
-
-            using (host)
+            try
             {
-                try
-                {
-                    await host.WorkflowCoordinatorRunAsync(cancellationToken);
-                }
-                catch (Exception ex)
-                {
-                    Log.Fatal(ex, "Host terminated unexpectedly");
-                }
-                finally
-                {
-                    Log.CloseAndFlush();
-                }
+                host = builder.Build();
+                var cancellationToken = new WebJobsShutdownWatcher().Token;
+                await host.RunAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex, "Host terminated unexpectedly");
+            }
+            finally
+            {
+                Log.CloseAndFlush();
+                host?.Dispose();
             }
         }
     }


### PR DESCRIPTION
We were getting the Azure access token for SQL transport in `Program.cs` and passing it as a string to the NSB class via secrets config. Azure tokens expire after 1 hour. Might not be the problem and/or might affect our other connections?

When we setup SQL Server as the transport layer we use a factory, passed as a function. So before this PR, this would just create new connections using the string token from startup. NSB appears to be opening new connections from the factory all the time.

Now we're going to call `GetAccessTokenAsync` every time. I've plumbed the token provider in as a singleton to ensure the caching functionality of `GetAccessTokenAsync` works correctly. It will use its cache for the first 55 minutes of a token's lifetime then fetch a new one.

 ```
var transport = this.UseTransport<SqlServerTransport>()
             .Transactions(TransportTransactionMode.SendsAtomicWithReceive).UseCustomSqlConnectionFactory(
                    async () =>
                    {
                        var con = new SqlConnection();
                        try
                        {
                            con.ConnectionString = nsbSecretsConfig.NsbDbConnectionString;
                            if (!nsbConfig.IsLocalDevelopment && azureServiceTokenProvider != null)
                            {
                                con.AccessToken = await azureServiceTokenProvider.GetAccessTokenAsync(nsbConfig.AzureDbTokenUrl.ToString());
                            }
                            await con.OpenAsync().ConfigureAwait(false);
                            return con;
                        }
                        catch
                        {
                            con.Dispose();
                            throw;
                        }
                    });
```

Downside == the context properties I have had to use to bring the singleton from `ConfigureServices` into `UseNServiceBus` inside `Program.cs`. See _Bridge to Terabithia_ :) Perhaps you have some other ideas folk?

**UPDATE**

Such underlying NSB errors are caught in an infinite retry loop by the default behaviour for critical events. As far as NSB is concerned, it logs but perhaps is not hooked up to the application logging fully? (they don't appear in the Db logs).

We're exposed to future problems with any intermittent underlying NSB behaviour if we don't ensure we're logging all errors.

- I've refactored startup to ensure SQL connection exceptions are caught and logged
- There is currently and 'on critical' behaviour custom handler committed to WIP but will be removing as I think that is more appropriate to scenarios where we would circuit break and shut down. NOW REMOVED.
- Had success at a refactor of the transport SQL func with Polly to at least reduce the number of log entries we'd get if we let it log there but had to do some `ConfigureWait(true)`, which might be fine but would need to dig too deep into NSB code to be certain so have **not committed** it. NOT USED.

Other work:

- Upgraded Microsoft.Azure.WebJobs 3.0.14 -> 3.0.16 but nothing relevant in release notes.
- Took opportunity to add code to ensure web job stops on app itself stopping.