### PR TITLE
Features/update session file xml with sources

### DIFF
--- a/src/Portal/Portal.UnitTests/EditDatabaseTests.cs
+++ b/src/Portal/Portal.UnitTests/EditDatabaseTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
@@ -174,13 +173,17 @@ namespace Portal.UnitTests
             _dbContext.LinkedDocument.Add(new LinkedDocument()
             {
                 ProcessId = ProcessId,
-                Status = SourceDocumentRetrievalStatus.FileGenerated.ToString()
+                Status = SourceDocumentRetrievalStatus.FileGenerated.ToString(),
+                Filename = "Testing1.tif",
+                Filepath = "c:\\Temp"
             });
 
             _dbContext.LinkedDocument.Add(new LinkedDocument()
             {
                 ProcessId = ProcessId,
-                Status = SourceDocumentRetrievalStatus.FileGenerated.ToString()
+                Status = SourceDocumentRetrievalStatus.FileGenerated.ToString(),
+                Filename = "Testing2.tif",
+                Filepath = "c:\\Temp"
             });
 
             await _dbContext.SaveChangesAsync();
@@ -200,7 +203,9 @@ namespace Portal.UnitTests
             _dbContext.DatabaseDocumentStatus.Add(new DatabaseDocumentStatus()
             {
                 ProcessId = ProcessId,
-                Status = SourceDocumentRetrievalStatus.FileGenerated.ToString()
+                Status = SourceDocumentRetrievalStatus.FileGenerated.ToString(),
+                Filename = "Testing.tif",
+                Filepath = "c:\\Temp"
             });
 
 
@@ -220,7 +225,7 @@ namespace Portal.UnitTests
 
             await _editDatabaseModel.OnGetAsync(ProcessId, "Assess");
 
-            Assert.AreEqual("Source", _editDatabaseModel.SourceDocuments[0].DocumentName);
+            Assert.AreEqual("Testing.tif", _editDatabaseModel.SourceDocuments[0].DocumentName);
 
         }
 
@@ -233,14 +238,15 @@ namespace Portal.UnitTests
             {
                 ProcessId = ProcessId,
                 Status = SourceDocumentRetrievalStatus.FileGenerated.ToString(),
-                SourceDocumentName = "LinkedSource"
+                Filename = "Testing.tif",
+                Filepath = "c:\\Temp"
             });
 
             await _dbContext.SaveChangesAsync();
 
             await _editDatabaseModel.OnGetAsync(ProcessId, "Assess");
 
-            Assert.AreEqual("LinkedSource", _editDatabaseModel.SourceDocuments[1].DocumentName);
+            Assert.AreEqual("Testing.tif", _editDatabaseModel.SourceDocuments[1].DocumentName);
 
         }
 
@@ -253,7 +259,8 @@ namespace Portal.UnitTests
             {
                 ProcessId = ProcessId,
                 Status = SourceDocumentRetrievalStatus.FileGenerated.ToString(),
-                SourceDocumentName = "DatabaseSource"
+                Filename = "Testing.tif",
+                Filepath = "c:\\Temp"
 
             });
 
@@ -261,7 +268,7 @@ namespace Portal.UnitTests
 
             await _editDatabaseModel.OnGetAsync(ProcessId, "Assess");
 
-            Assert.AreEqual("DatabaseSource", _editDatabaseModel.SourceDocuments[1].DocumentName);
+            Assert.AreEqual("Testing.tif", _editDatabaseModel.SourceDocuments[1].DocumentName);
 
         }
 
@@ -273,13 +280,17 @@ namespace Portal.UnitTests
             _dbContext.LinkedDocument.Add(new LinkedDocument()
             {
                 ProcessId = ProcessId,
-                Status = SourceDocumentRetrievalStatus.FileGenerated.ToString()
+                Status = SourceDocumentRetrievalStatus.FileGenerated.ToString(),
+                Filename = "Testing1.tif",
+                Filepath = "c:\\Temp"
             });
 
             _dbContext.DatabaseDocumentStatus.Add(new DatabaseDocumentStatus()
             {
                 ProcessId = ProcessId,
-                Status = SourceDocumentRetrievalStatus.FileGenerated.ToString()
+                Status = SourceDocumentRetrievalStatus.FileGenerated.ToString(),
+                Filename = "Testing2.tif",
+                Filepath = "c:\\Temp"
             });
 
             await _dbContext.SaveChangesAsync();
@@ -326,7 +337,7 @@ namespace Portal.UnitTests
             await _editDatabaseModel.OnGetAsync(ProcessId, "Assess");
 
             Assert.AreEqual(1, _editDatabaseModel.SourceDocuments.Count);
-            Assert.AreEqual("Source", _editDatabaseModel.SourceDocuments[0].DocumentName);
+            Assert.AreEqual("Testing.tif", _editDatabaseModel.SourceDocuments[0].DocumentName);
 
         }
 
@@ -432,7 +443,9 @@ namespace Portal.UnitTests
             _dbContext.PrimaryDocumentStatus.Add(new PrimaryDocumentStatus()
             {
                 ProcessId = ProcessId,
-                Status = SourceDocumentRetrievalStatus.FileGenerated.ToString()
+                Status = SourceDocumentRetrievalStatus.FileGenerated.ToString(),
+                Filename = "Testing.tif",
+                Filepath = "c:\\Temp"
             });
 
             _dbContext.DbAssessmentAssessData.Add(new DbAssessmentAssessData()

--- a/src/Portal/Portal.UnitTests/EditDatabaseTests.cs
+++ b/src/Portal/Portal.UnitTests/EditDatabaseTests.cs
@@ -221,7 +221,6 @@ namespace Portal.UnitTests
             await _editDatabaseModel.OnGetAsync(ProcessId, "Assess");
 
             Assert.AreEqual("Source", _editDatabaseModel.SourceDocuments[0].DocumentName);
-            Assert.AreEqual("Not implemented", _editDatabaseModel.SourceDocuments[0].FileExtension);
 
         }
 
@@ -242,7 +241,6 @@ namespace Portal.UnitTests
             await _editDatabaseModel.OnGetAsync(ProcessId, "Assess");
 
             Assert.AreEqual("LinkedSource", _editDatabaseModel.SourceDocuments[1].DocumentName);
-            Assert.AreEqual("Not implemented", _editDatabaseModel.SourceDocuments[1].FileExtension);
 
         }
 
@@ -264,7 +262,6 @@ namespace Portal.UnitTests
             await _editDatabaseModel.OnGetAsync(ProcessId, "Assess");
 
             Assert.AreEqual("DatabaseSource", _editDatabaseModel.SourceDocuments[1].DocumentName);
-            Assert.AreEqual("Not implemented", _editDatabaseModel.SourceDocuments[1].FileExtension);
 
         }
 

--- a/src/Portal/Portal.UnitTests/SessionFileGeneratorTests.cs
+++ b/src/Portal/Portal.UnitTests/SessionFileGeneratorTests.cs
@@ -111,11 +111,11 @@ namespace Portal.UnitTests
             Assert.IsNotNull(sessionFile);
             Assert.IsNotNull(sessionFile.DataSources);
             Assert.AreEqual(hpdUsername,
-                sessionFile.DataSources.DataSource.SourceParam.USERNAME);
+                sessionFile.DataSources.DataSource[0].SourceParam.USERNAME);
             Assert.AreEqual(hpdUsername,
-                sessionFile.DataSources.DataSource.SourceParam.ASSIGNED_USER);
+                sessionFile.DataSources.DataSource[0].SourceParam.ASSIGNED_USER);
             Assert.AreEqual(_secretsConfig.Value.HpdServiceName,
-                sessionFile.DataSources.DataSource.SourceParam.SERVICENAME);
+                sessionFile.DataSources.DataSource[0].SourceParam.SERVICENAME);
         }
         
         [Test]
@@ -156,11 +156,11 @@ namespace Portal.UnitTests
             Assert.IsNotNull(sessionFile);
             Assert.IsNotNull(sessionFile.DataSources);
             Assert.AreEqual(selectedUsages[0],
-                sessionFile.DataSources.DataSource.SourceParam.USAGE);
+                sessionFile.DataSources.DataSource[0].SourceParam.USAGE);
 
             Assert.AreEqual($":HPD:Project:|{carisproject.ProjectName}",
-                sessionFile.DataSources.DataSource.SourceString);
-            Assert.That(sessionFile.DataSources.DataSource.SourceParam.SELECTEDPROJECTUSAGES.Value, Is.EqualTo(selectedUsages));
+                sessionFile.DataSources.DataSource[0].SourceString);
+            Assert.That(sessionFile.DataSources.DataSource[0].SourceParam.SELECTEDPROJECTUSAGES.Value, Is.EqualTo(selectedUsages));
 
 
             Assert.IsNotNull(sessionFile.Views);
@@ -198,7 +198,7 @@ namespace Portal.UnitTests
 
             Assert.IsNotNull(sessionFile);
             Assert.IsNotNull(sessionFile.DataSources);
-            Assert.AreEqual("TestWorkspace", sessionFile.DataSources.DataSource.SourceParam.WORKSPACE);
+            Assert.AreEqual("TestWorkspace", sessionFile.DataSources.DataSource[0].SourceParam.WORKSPACE);
         }
     }
 }

--- a/src/Portal/Portal/Data/TasksSeedData.json
+++ b/src/Portal/Portal/Data/TasksSeedData.json
@@ -386,7 +386,7 @@
         "ContentServiceId": null,
         "Status": "FileGenerated",
         "Filename": "RSDRA2018000094806_1.tif",
-        "Filepath": "\\\\engineering.ukho.gov.uk\\dfs\\AppData\\HDB\\DEV1\\SDRADocuments",
+        "Filepath": "<add path>",
         "created": "2020-01-01T00:00:00"
       }
     ],
@@ -444,7 +444,7 @@
       "CorrelationId": "6855f620-375f-4842-a5a4-8ac676bb3e49",
       "Status": "FileGenerated",
       "Filename": "GeoReferenced_RSDRA2018000030860_1.TIF",
-      "Filepath": "\\\\engineering.ukho.gov.uk\\dfs\\AppData\\HDB\\DEV1\\SDRADocuments"
+      "Filepath": "<add path>"
     },
     "DatabaseDocumentStatus": [
       {
@@ -456,7 +456,7 @@
         "created": "2020-01-01T00:00:00",
         "Status": "FileGenerated",
         "Filename": "RSDRA2018000030860_1.TIF",
-        "Filepath": "\\\\engineering.ukho.gov.uk\\dfs\\AppData\\HDB\\DEV1\\SDRADocuments"
+        "Filepath": "<add path>"
       }
     ]
   },

--- a/src/Portal/Portal/Data/TasksSeedData.json
+++ b/src/Portal/Portal/Data/TasksSeedData.json
@@ -384,7 +384,9 @@
         "linkType": "Forward",
         "linkedSdocId": 606203,
         "ContentServiceId": null,
-        "Status": "Started",
+        "Status": "FileGenerated",
+        "Filename": "RSDRA2018000094806_1.tif",
+        "Filepath": "\\\\engineering.ukho.gov.uk\\dfs\\AppData\\HDB\\DEV1\\SDRADocuments",
         "created": "2020-01-01T00:00:00"
       }
     ],
@@ -438,9 +440,11 @@
       "processId": 125,
       "SdocId": 206733,
       "ContentServiceId": null,
-      "Status": "Ready",
       "StartedAt": "2020-01-03T00:00:00",
-      "CorrelationId": "6855f620-375f-4842-a5a4-8ac676bb3e49"
+      "CorrelationId": "6855f620-375f-4842-a5a4-8ac676bb3e49",
+      "Status": "FileGenerated",
+      "Filename": "GeoReferenced_RSDRA2018000030860_1.TIF",
+      "Filepath": "\\\\engineering.ukho.gov.uk\\dfs\\AppData\\HDB\\DEV1\\SDRADocuments"
     },
     "DatabaseDocumentStatus": [
       {
@@ -449,8 +453,10 @@
         "sourceDocumentName": "HUA HIN",
         "sourceDocumentType": "Chart Panel Navigational or Repromat",
         "ContentServiceId": null,
-        "Status": "Started",
-        "created": "2020-01-01T00:00:00"
+        "created": "2020-01-01T00:00:00",
+        "Status": "FileGenerated",
+        "Filename": "RSDRA2018000030860_1.TIF",
+        "Filepath": "\\\\engineering.ukho.gov.uk\\dfs\\AppData\\HDB\\DEV1\\SDRADocuments"
       }
     ]
   },

--- a/src/Portal/Portal/Helpers/SessionFileGenerator.cs
+++ b/src/Portal/Portal/Helpers/SessionFileGenerator.cs
@@ -81,7 +81,9 @@ namespace Portal.Helpers
             var sources = new List<SessionFile.DataSourceNode>();
 
             SetUsages(sources, hpdUser, workspaceAffected, carisProjectDetails, selectedHpdUsages);
-            SetSources(sources, selectedSources);
+
+            if (selectedSources?.Count > 0)
+                SetSources(sources, selectedSources);
 
             return new SessionFile
             {
@@ -137,20 +139,20 @@ namespace Portal.Helpers
         {
 
             sources.AddRange(selectedSources.Select(s => new SessionFile.DataSourceNode()
+            {
+                SourceString = s,
+                SourceParam = new SessionFile.SourceParamNode()
                 {
-                    SourceString = s,
-                    SourceParam = new SessionFile.SourceParamNode()
+                    DisplayName = new SessionFile.DisplayNameNode()
                     {
-                        DisplayName = new SessionFile.DisplayNameNode()
-                        {
-                            Value = Path.GetFileNameWithoutExtension(s)
-                        },
-                        SurfaceString = new SessionFile.SurfaceStringNode()
-                        {
-                            Value = s
-                        }
+                        Value = Path.GetFileNameWithoutExtension(s)
+                    },
+                    SurfaceString = new SessionFile.SurfaceStringNode()
+                    {
+                        Value = s
                     }
-                }));
+                }
+            }));
         }
     }
 }

--- a/src/Portal/Portal/Models/SessionFile.cs
+++ b/src/Portal/Portal/Models/SessionFile.cs
@@ -52,6 +52,10 @@ namespace Portal.Models
             public string PROJECT_ID { get; set; }
             [XmlElement(ElementName = "SELECTEDPROJECTUSAGES")]
             public SelectedProjectUsages SELECTEDPROJECTUSAGES { get; set; }
+            [XmlElement(ElementName = "DisplayName")]
+            public DisplayNameNode DisplayName { get; set; }
+            [XmlElement(ElementName = "SurfaceString")]
+            public SurfaceStringNode SurfaceString { get; set; }
         }
 
         [XmlRoot(ElementName = "DataSource")]
@@ -69,7 +73,7 @@ namespace Portal.Models
         public class DataSourcesNode
         {
             [XmlElement(ElementName = "DataSource")]
-            public DataSourceNode DataSource { get; set; }
+            public List<DataSourceNode> DataSource { get; set; }
         }
 
         [XmlRoot(ElementName = "displayLayer")]
@@ -138,5 +142,20 @@ namespace Portal.Models
             [XmlElement(ElementName = "Property")]
             public List<PropertyNode> Property { get; set; }
         }
+
+        [XmlRoot(ElementName = "DisplayName")]
+        public class DisplayNameNode
+        {
+            [XmlElement(ElementName = "value")]
+            public string Value { get; set; }
+        }
+
+        [XmlRoot(ElementName = "SurfaceString")]
+        public class SurfaceStringNode
+        {
+            [XmlElement(ElementName = "value")]
+            public string Value { get; set; }
+        }
+
     }
 }

--- a/src/Portal/Portal/Pages/DbAssessment/_EditDatabase.cshtml
+++ b/src/Portal/Portal/Pages/DbAssessment/_EditDatabase.cshtml
@@ -167,7 +167,7 @@
                                         </td>
                                         <td>
                                             <div class="checkbox-wrapper">
-                                                <input type="checkbox" id="@id" data-source-filename="@(source.DocumentFullName)">
+                                                <input type="checkbox" id="@id" data-source-filename="@(source.DocumentName)" data-source-fullfilename="@(source.DocumentFullName)">
                                                 <label for="@id"></label>
                                             </div>
                                         </td>

--- a/src/Portal/Portal/Pages/DbAssessment/_EditDatabase.cshtml
+++ b/src/Portal/Portal/Pages/DbAssessment/_EditDatabase.cshtml
@@ -1,5 +1,6 @@
 ﻿@page
 
+@using System.IO
 @model Portal.Pages.DbAssessment._EditDatabaseModel
 
 @{ Layout = null; }
@@ -166,7 +167,7 @@
                                         </td>
                                         <td>
                                             <div class="checkbox-wrapper">
-                                                <input type="checkbox" id="@id" data-source-filename="@(source.DocumentName + "." + source.FileExtension)">
+                                                <input type="checkbox" id="@id" data-source-filename="@(source.DocumentFullName)">
                                                 <label for="@id"></label>
                                             </div>
                                         </td>

--- a/src/Portal/Portal/Pages/DbAssessment/_EditDatabase.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_EditDatabase.cshtml.cs
@@ -103,10 +103,7 @@ namespace Portal.Pages.DbAssessment
             SourcesSelectionPageLength = _generalConfig.Value.SourcesSelectionPageLength;
             CarisProjectNameCharacterLimit = _generalConfig.Value.CarisProjectNameCharacterLimit;
 
-            var filename = Path.GetFileNameWithoutExtension(_generalConfig.Value.SessionFilename);
-            var ext = Path.GetExtension(_generalConfig.Value.SessionFilename);
-            SessionFilename = $"{filename}_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}{ext}";
-
+            SessionFilename = GenerateSessionFilename();
         }
 
         public async Task<JsonResult> OnGetWorkspacesAsync()
@@ -448,6 +445,13 @@ namespace Portal.Pages.DbAssessment
             }
 
             ProjectName = CarisProjectDetails.ProjectName;
+        }
+
+        private string GenerateSessionFilename()
+        {
+            var filename = Path.GetFileNameWithoutExtension(_generalConfig.Value.SessionFilename);
+            var ext = Path.GetExtension(_generalConfig.Value.SessionFilename);
+            return $"{filename}_{DateTime.Now:yyMMdd-HHmmss}{ext}"; // $"{filename}_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}{ext}"
         }
     }
 }

--- a/src/Portal/Portal/Pages/DbAssessment/_EditDatabase.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_EditDatabase.cshtml.cs
@@ -102,54 +102,11 @@ namespace Portal.Pages.DbAssessment
             UsagesSelectionPageLength = _generalConfig.Value.UsagesSelectionPageLength;
             SourcesSelectionPageLength = _generalConfig.Value.SourcesSelectionPageLength;
             CarisProjectNameCharacterLimit = _generalConfig.Value.CarisProjectNameCharacterLimit;
-            SessionFilename = _generalConfig.Value.SessionFilename;
-        }
 
-        private async Task GetSourceDocuments(int processId)
-        {
-            var assessmentData = await _dbContext.AssessmentData
-                .FirstOrDefaultAsync(ad => ad.ProcessId == processId);
-            var primaryDocumentStatus = await _dbContext.PrimaryDocumentStatus
-                .FirstOrDefaultAsync(pds => pds.ProcessId == processId);
+            var filename = Path.GetFileNameWithoutExtension(_generalConfig.Value.SessionFilename);
+            var ext = Path.GetExtension(_generalConfig.Value.SessionFilename);
+            SessionFilename = $"{filename}_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}{ext}";
 
-            if (assessmentData != null && primaryDocumentStatus != null &&
-                primaryDocumentStatus.Status == SourceDocumentRetrievalStatus.FileGenerated.ToString())
-            {
-                var primarySourceDocument = new SourceViewModel()
-                {
-                    DocumentName = assessmentData.SourceDocumentName,
-                    FileExtension = "Not implemented",
-                    Path = _generalConfig.Value.SourceDocumentWriteableFolderName
-                };
-
-                SourceDocuments.Add(primarySourceDocument);
-            }
-
-            var linkedDocuments = await _dbContext.LinkedDocument
-                .Where(ld => ld.ProcessId == processId &&
-                                          ld.Status == SourceDocumentRetrievalStatus.FileGenerated.ToString())
-                .Select(ld => new SourceViewModel()
-                {
-                    DocumentName = ld.SourceDocumentName,
-                    FileExtension = "Not implemented",
-                    Path = _generalConfig.Value.SourceDocumentWriteableFolderName
-                })
-                .ToListAsync();
-
-            SourceDocuments.AddRange(linkedDocuments);
-
-            var databaseDocuments = await _dbContext.DatabaseDocumentStatus
-                .Where(dd => dd.ProcessId == processId &&
-                                                dd.Status == SourceDocumentRetrievalStatus.FileGenerated.ToString())
-                .Select(dd => new SourceViewModel()
-                {
-                    DocumentName = dd.SourceDocumentName,
-                    FileExtension = "Not implemented",
-                    Path = _generalConfig.Value.SourceDocumentWriteableFolderName
-                })
-                .ToListAsync();
-
-            SourceDocuments.AddRange(databaseDocuments);
         }
 
         public async Task<JsonResult> OnGetWorkspacesAsync()
@@ -261,6 +218,53 @@ namespace Portal.Pages.DbAssessment
             await _dbContext.SaveChangesAsync();
 
             return StatusCode(200);
+        }
+        
+        private async Task GetSourceDocuments(int processId)
+        {
+            var assessmentData = await _dbContext.AssessmentData
+                .FirstOrDefaultAsync(ad => ad.ProcessId == processId);
+            var primaryDocumentStatus = await _dbContext.PrimaryDocumentStatus
+                .FirstOrDefaultAsync(pds => pds.ProcessId == processId);
+
+            if (assessmentData != null && primaryDocumentStatus != null &&
+                primaryDocumentStatus.Status == SourceDocumentRetrievalStatus.FileGenerated.ToString())
+            {
+                var primarySourceDocument = new SourceViewModel()
+                {
+                    DocumentName = assessmentData.SourceDocumentName,
+                    FileExtension = "Not implemented",
+                    Path = _generalConfig.Value.SourceDocumentWriteableFolderName
+                };
+
+                SourceDocuments.Add(primarySourceDocument);
+            }
+
+            var linkedDocuments = await _dbContext.LinkedDocument
+                .Where(ld => ld.ProcessId == processId &&
+                                          ld.Status == SourceDocumentRetrievalStatus.FileGenerated.ToString())
+                .Select(ld => new SourceViewModel()
+                {
+                    DocumentName = ld.SourceDocumentName,
+                    FileExtension = "Not implemented",
+                    Path = _generalConfig.Value.SourceDocumentWriteableFolderName
+                })
+                .ToListAsync();
+
+            SourceDocuments.AddRange(linkedDocuments);
+
+            var databaseDocuments = await _dbContext.DatabaseDocumentStatus
+                .Where(dd => dd.ProcessId == processId &&
+                                                dd.Status == SourceDocumentRetrievalStatus.FileGenerated.ToString())
+                .Select(dd => new SourceViewModel()
+                {
+                    DocumentName = dd.SourceDocumentName,
+                    FileExtension = "Not implemented",
+                    Path = _generalConfig.Value.SourceDocumentWriteableFolderName
+                })
+                .ToListAsync();
+
+            SourceDocuments.AddRange(databaseDocuments);
         }
 
         private async Task<int> CreateCarisProject(int processId, string projectName)

--- a/src/Portal/Portal/Pages/DbAssessment/_EditDatabase.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_EditDatabase.cshtml.cs
@@ -219,19 +219,16 @@ namespace Portal.Pages.DbAssessment
         
         private async Task GetSourceDocuments(int processId)
         {
-            var assessmentData = await _dbContext.AssessmentData
-                .FirstOrDefaultAsync(ad => ad.ProcessId == processId);
             var primaryDocumentStatus = await _dbContext.PrimaryDocumentStatus
                 .FirstOrDefaultAsync(pds => pds.ProcessId == processId);
 
-            if (assessmentData != null && primaryDocumentStatus != null &&
+            if (primaryDocumentStatus != null &&
                 primaryDocumentStatus.Status == SourceDocumentRetrievalStatus.FileGenerated.ToString())
             {
                 var primarySourceDocument = new SourceViewModel()
                 {
-                    DocumentName = assessmentData.SourceDocumentName,
-                    FileExtension = "Not implemented",
-                    Path = _generalConfig.Value.SourceDocumentWriteableFolderName
+                    DocumentName = primaryDocumentStatus.Filename,
+                    DocumentFullName = Path.Combine(primaryDocumentStatus.Filepath, primaryDocumentStatus.Filename)
                 };
 
                 SourceDocuments.Add(primarySourceDocument);
@@ -242,9 +239,8 @@ namespace Portal.Pages.DbAssessment
                                           ld.Status == SourceDocumentRetrievalStatus.FileGenerated.ToString())
                 .Select(ld => new SourceViewModel()
                 {
-                    DocumentName = ld.SourceDocumentName,
-                    FileExtension = "Not implemented",
-                    Path = _generalConfig.Value.SourceDocumentWriteableFolderName
+                    DocumentName = ld.Filename,
+                    DocumentFullName = Path.Combine(ld.Filepath, ld.Filename)
                 })
                 .ToListAsync();
 
@@ -255,9 +251,8 @@ namespace Portal.Pages.DbAssessment
                                                 dd.Status == SourceDocumentRetrievalStatus.FileGenerated.ToString())
                 .Select(dd => new SourceViewModel()
                 {
-                    DocumentName = dd.SourceDocumentName,
-                    FileExtension = "Not implemented",
-                    Path = _generalConfig.Value.SourceDocumentWriteableFolderName
+                    DocumentName = dd.Filename,
+                    DocumentFullName = Path.Combine(dd.Filepath, dd.Filename)
                 })
                 .ToListAsync();
 

--- a/src/Portal/Portal/ViewModels/SourceViewModel.cs
+++ b/src/Portal/Portal/ViewModels/SourceViewModel.cs
@@ -3,7 +3,6 @@
     public class SourceViewModel
     {
         public string DocumentName { get; set; }
-        public string FileExtension { get; set; }
-        public string Path { get; set; }    
+        public string DocumentFullName { get; set; }    
     }
 }

--- a/src/Portal/Portal/wwwroot/js/LaunchCarisModal.js
+++ b/src/Portal/Portal/wwwroot/js/LaunchCarisModal.js
@@ -129,8 +129,8 @@ function attachLaunchSourceEditorDownloadHandler() {
             selectedHpdUsages.push($(this).data("usage-name"));
         });
 
-        $(".selectedSource").each(function () {
-            selectedSources.push($(this).data("source-filename"));
+        $("#sourcesSelection input:checkbox:checked").each(function () {
+            selectedSources.push($(this).data("source-fullfilename"));
         });
 
         if (selectedHpdUsages.length === 0) {


### PR DESCRIPTION
1) Updated seeding to use some existing source files to help with testing
2) Updated SessionFileGenerator to store sources under DataSource node
3) Updated SessionFileGenerator to store selected sources
4) Added two new nodes to SourceParamNode (DataSourceNode): DisplayNameNode and SurfaceStringNode to store source files
5) Updated EditDatabase partial to use the new columns: FileName and FilePath from PrimaryDocumentStatus, LinkedDocument, and DatabaseDocumentStatus tables
6) Updated EditDatabase partial to use the full filename (with path) 
7) Session filename has timestamp included (eg: HPDSessionFile_**200420-120438**.wrk)