### PR TITLE
Features/use publish instead of sendlocal

### DIFF
--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator.UnitTests/SourceDocumentRetrievalSagaTests.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator.UnitTests/SourceDocumentRetrievalSagaTests.cs
@@ -286,7 +286,6 @@ namespace SourceDocumentCoordinator.UnitTests
         [Test]
         public async Task Test_GetDocumentRequestQueueStatusCommand_When_Request_Queue_Status_Returns_Error_Code_Does_Not_Fire_Timeout_And_InitiateSourceDocumentRetrievalCommand_Is_Sent_With_GeoReferenced_Set_to_False(
                         [Values(
-                            RequestQueueStatusReturnCodeEnum.NotGeoreferenced,
                             RequestQueueStatusReturnCodeEnum.ConversionFailed,
                             RequestQueueStatusReturnCodeEnum.NotSuitableForConversion,
             RequestQueueStatusReturnCodeEnum.ConversionTimeOut)]
@@ -319,7 +318,7 @@ namespace SourceDocumentCoordinator.UnitTests
             Assert.IsNull(timeoutCommand, $"Timeout '{nameof(GetDocumentRequestQueueStatusCommand)}' should only be fired on successful queuing");
 
             // Ensure new InitiateSourceDocumentRetrievalEvent is sent
-            var initiateSourceDocumentRetrievalCommand = _handlerContext.SentMessages.SingleOrDefault(t =>
+            var initiateSourceDocumentRetrievalCommand = _handlerContext.PublishedMessages.SingleOrDefault(t =>
                 t.Message is InitiateSourceDocumentRetrievalEvent);
             Assert.IsNotNull(initiateSourceDocumentRetrievalCommand, $"No message of type {nameof(InitiateSourceDocumentRetrievalEvent)} seen.");
 

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Sagas/SourceDocumentRetrievalSaga.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Sagas/SourceDocumentRetrievalSaga.cs
@@ -178,7 +178,7 @@ namespace SourceDocumentCoordinator.Sagas
                         SourceDocumentId = message.SourceDocumentId,
                         GeoReferenced = false
                     };
-                    await context.SendLocal(msg);
+                    await context.Publish(msg);
                     break;
                 case RequestQueueStatusReturnCodeEnum.FolderNotWritable:
                     MarkAsComplete();

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Sagas/SourceDocumentRetrievalSaga.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Sagas/SourceDocumentRetrievalSaga.cs
@@ -132,6 +132,7 @@ namespace SourceDocumentCoordinator.Sagas
             switch ((RequestQueueStatusReturnCodeEnum)sourceDocument.Code.Value)
             {
                 case RequestQueueStatusReturnCodeEnum.Success:
+                case RequestQueueStatusReturnCodeEnum.NotGeoreferenced:
                     // Doc Ready; update DB;
                     await SourceDocumentHelper.UpdateSourceDocumentStatus(_documentStatusFactory, Data.ProcessId, Data.SourceDocumentId, SourceDocumentRetrievalStatus.Ready, Data.SourceType, message.CorrelationId);
 
@@ -167,7 +168,6 @@ namespace SourceDocumentCoordinator.Sagas
                 case RequestQueueStatusReturnCodeEnum.ConversionFailed:
                 case RequestQueueStatusReturnCodeEnum.ConversionTimeOut:
                 case RequestQueueStatusReturnCodeEnum.NotSuitableForConversion:
-                case RequestQueueStatusReturnCodeEnum.NotGeoreferenced:
 
                     MarkAsComplete();
 

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/SourceDocumentCoordinatorConfig.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/SourceDocumentCoordinatorConfig.cs
@@ -55,6 +55,10 @@ namespace SourceDocumentCoordinator
                 assembly: typeof(InitiateSourceDocumentRetrievalEvent).Assembly,
                 publisherEndpoint: nsbConfig.WorkflowCoordinatorName);
 
+            routing.RegisterPublisher(
+                assembly: typeof(InitiateSourceDocumentRetrievalEvent).Assembly,
+                publisherEndpoint: nsbConfig.SourceDocumentCoordinatorName);
+
             // Persistence
 
             var persistence = this.UsePersistence<SqlPersistence>();


### PR DESCRIPTION
1) Updated Unit tests
2) Fixed re-sending InitiateSourceDocumentRetrievalEvent by using Publish instead of SendLocal
3) Fixed no-geo-referenced error code 20 to be treated as success
