### PR TITLE
Fixing exception when running accessibility tests

### DIFF
--- a/src/Common.TestAutomation.Framework/Logging/ITestLogging.cs
+++ b/src/Common.TestAutomation.Framework/Logging/ITestLogging.cs
@@ -1,0 +1,8 @@
+﻿namespace Common.TestAutomation.Framework.Logging
+{
+    public interface ITestLogging
+    {
+        void LogLineBreak();
+        void Log(string message = "");
+    }
+}

--- a/src/Common.TestAutomation.Framework/Logging/NunitTestLogging.cs
+++ b/src/Common.TestAutomation.Framework/Logging/NunitTestLogging.cs
@@ -1,0 +1,17 @@
+﻿using NUnit.Framework;
+
+namespace Common.TestAutomation.Framework.Logging
+{
+    public class NunitTestLogging : ITestLogging
+    {
+        public virtual void LogLineBreak()
+        {
+            Log();
+        }
+
+        public void Log(string message = "")
+        {
+            TestContext.Out.WriteLine(message);
+        }
+    }
+}

--- a/src/Common.TestAutomation.Framework/Logging/SpecFlowLogging.cs
+++ b/src/Common.TestAutomation.Framework/Logging/SpecFlowLogging.cs
@@ -6,16 +6,17 @@ using NUnit.Framework;
 using OpenQA.Selenium;
 using TechTalk.SpecFlow;
 
-namespace Common.TestAutomation.Framework
+namespace Common.TestAutomation.Framework.Logging
 {
     [Binding]
-    public class Logging
+    public class SpecFlowLogging : NunitTestLogging
     {
         private readonly FeatureContext _featureContext;
         private readonly IObjectContainer _objectContainer;
         private readonly ScenarioContext _scenarioContext;
 
-        public Logging(FeatureContext featureContext, ScenarioContext scenarioContext, IObjectContainer objectContainer)
+        public SpecFlowLogging(FeatureContext featureContext, ScenarioContext scenarioContext,
+            IObjectContainer objectContainer)
         {
             _featureContext = featureContext;
             _scenarioContext = scenarioContext;
@@ -43,9 +44,9 @@ namespace Common.TestAutomation.Framework
         }
 
         [AfterStep]
-        public void LogLineBreak()
+        public override void LogLineBreak()
         {
-            Log();
+            base.LogLineBreak();
         }
 
         [AfterScenario]
@@ -80,11 +81,6 @@ namespace Common.TestAutomation.Framework
                 screenShot.SaveAsFile(tempFilePath);
                 TestContext.AddTestAttachment(tempFilePath);
             }
-        }
-
-        public void Log(string message = "")
-        {
-            TestContext.Out.WriteLine(message);
         }
     }
 }

--- a/src/Common.TestAutomation.Framework/WebDriverSupport.cs
+++ b/src/Common.TestAutomation.Framework/WebDriverSupport.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using BoDi;
+using Common.TestAutomation.Framework.Logging;
 using Common.TestAutomation.Framework.Pages;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
@@ -40,7 +41,7 @@ namespace Common.TestAutomation.Framework
 
             try
             {
-                var logger = _objectContainer.Resolve<Logging>();
+                var logger = _objectContainer.Resolve<ITestLogging>();
 
                 var eventDriver = new EventFiringWebDriver(new ChromeDriver(chromeDriverDirectory));
                 eventDriver.Navigating += (sender, e) => logger.Log($"    Navigating to {e.Url}");

--- a/src/NCNEPortal.AccessibilityTests/AccessibilityTests.cs
+++ b/src/NCNEPortal.AccessibilityTests/AccessibilityTests.cs
@@ -2,6 +2,7 @@ using System;
 using BoDi;
 using Common.TestAutomation.Framework;
 using Common.TestAutomation.Framework.Axe;
+using Common.TestAutomation.Framework.Logging;
 using NCNEPortal.TestAutomation.Framework;
 using NCNEPortal.TestAutomation.Framework.Pages;
 using NUnit.Framework;
@@ -30,15 +31,23 @@ namespace NCNEPortal.AccessibilityTests
             _webDriverSupport?.DisposeWebdriver();
         }
 
+        [OneTimeSetUp]
+        public static void BeforeAllTests()
+        {
+            ConfigSupport.PopulateConfigsFromAzure();
+        }
+
         [SetUp]
         public void Setup()
         {
-            _configSupport.RegisterConfigs();
+            _objectContainer.RegisterTypeAs<NunitTestLogging, ITestLogging>();
+
+            _configSupport.RegisterAzureConfigs();
             _configSupport.RegisterLandingPage();
 
             _webDriverSupport.InitializeWebDriver();
             _webDriverSupport.SetLoginCookies();
-            
+
             _axePageEvaluator = _objectContainer.Resolve<AxePageEvaluator>();
             _axeResultAnalyser = _objectContainer.Resolve<AxeResultAnalyser>();
         }

--- a/src/Portal.TestAutomation.Framework/Setup/ConfigSupport.cs
+++ b/src/Portal.TestAutomation.Framework/Setup/ConfigSupport.cs
@@ -1,6 +1,7 @@
 ﻿using BoDi;
 using Common.Helpers;
 using Common.TestAutomation.Framework.Configs;
+using Common.TestAutomation.Framework.Logging;
 using Common.TestAutomation.Framework.Pages;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -27,7 +28,7 @@ namespace Portal.TestAutomation.Framework.Setup
         }
 
         [BeforeTestRun(Order = 1)]
-        public static void PopulateConfigs()
+        public static void PopulateConfigsFromAzure()
         {
             var appConfigRoot = AzureAppConfigConfigurationRoot.Instance;
             var keyVaultRoot = AzureKeyVaultConfigConfigurationRoot.Instance;
@@ -75,6 +76,12 @@ namespace Portal.TestAutomation.Framework.Setup
             _objectContainer.RegisterInstanceAs(_urls);
             _objectContainer.RegisterInstanceAs(_dbConfig);
             _objectContainer.RegisterInstanceAs(_workflowDbContext);
+        }
+
+        [BeforeScenario(Order = 5)]
+        public void RegisterSpecFlowLogger()
+        {
+            _objectContainer.RegisterTypeAs<SpecFlowLogging, ITestLogging>();
         }
 
         [BeforeScenario(Order = 19)]


### PR DESCRIPTION
Logging introduced by the Portal UI Tests broke the NCNE Accessibility tests as it was too closely coupled to SpecFlow (which the Accessibility tests do not use). This PR breaks that coupling by introducing a `ITestLogging` abstraction and implementations of that for both the NUnit and SpecFlow test runners.
Also moved the gathering of credentials from Azure for the NCNE automated tests to be done once at the start of the test run, similar to Poral automated tests. This will reduce unnecessary overhead when executing the tests.