### PR TITLE
Features/populate task information dates

### DIFF
--- a/src/Portal/Portal.UnitTests/TaskInformationTests.cs
+++ b/src/Portal/Portal.UnitTests/TaskInformationTests.cs
@@ -160,7 +160,7 @@ namespace Portal.UnitTests
                 Assert.AreEqual(new DateTime(2020, 07, 12).ToShortDateString(),
                     _taskInformationModel.DmEndDate);
             }
-            
+
         }
 
         [TestCase("Review")]
@@ -203,8 +203,286 @@ namespace Portal.UnitTests
 
             await _taskInformationModel.OnGetAsync(ProcessId, activityName);
 
-            Assert.AreEqual(new DateTime(2020, 05, 21),
+            Assert.AreEqual(new DateTime(2020, 05, 21).ToShortDateString(),
                     _taskInformationModel.ExternalEndDate);
         }
+
+        [TestCase("Review")]
+        [TestCase("Assess")]
+        [TestCase("Verify")]
+        public async Task Test_DmReceiptDate_is_set_when_calling_onGet(string activityName)
+        {
+            _dbContext.DbAssessmentReviewData.Add(new DbAssessmentReviewData()
+            {
+                ProcessId = ProcessId,
+                TaskType = "Simple"
+            });
+
+            _dbContext.DbAssessmentAssessData.Add(new DbAssessmentAssessData()
+            {
+                ProcessId = ProcessId,
+                TaskType = "Simple"
+            });
+
+            _dbContext.DbAssessmentVerifyData.Add(new DbAssessmentVerifyData()
+            {
+                ProcessId = ProcessId,
+                TaskType = "Simple"
+            });
+
+            _dbContext.WorkflowInstance.Add(new WorkflowInstance
+            {
+                ProcessId = 123,
+                ActivityName = activityName,
+                StartedAt = new DateTime(2020, 01, 01)
+            });
+
+            _dbContext.AssessmentData.Add(new AssessmentData
+            {
+                ProcessId = 123,
+                EffectiveStartDate = new DateTime(2020, 05, 01),
+                ReceiptDate = new DateTime(2020, 05, 01)
+            });
+
+            await _dbContext.SaveChangesAsync();
+
+            await _taskInformationModel.OnGetAsync(ProcessId, activityName);
+
+            Assert.AreEqual(new DateTime(2020, 01, 01),
+                _taskInformationModel.DmReceiptDate);
+        }
+
+        [TestCase("Review")]
+        [TestCase("Assess")]
+        [TestCase("Verify")]
+        public async Task Test_EffectiveReceiptDate_is_set_when_calling_onGet(string activityName)
+        {
+            _dbContext.DbAssessmentReviewData.Add(new DbAssessmentReviewData()
+            {
+                ProcessId = ProcessId,
+                TaskType = "Simple"
+            });
+
+            _dbContext.DbAssessmentAssessData.Add(new DbAssessmentAssessData()
+            {
+                ProcessId = ProcessId,
+                TaskType = "Simple"
+            });
+
+            _dbContext.DbAssessmentVerifyData.Add(new DbAssessmentVerifyData()
+            {
+                ProcessId = ProcessId,
+                TaskType = "Simple"
+            });
+
+            _dbContext.WorkflowInstance.Add(new WorkflowInstance
+            {
+                ProcessId = 123,
+                ActivityName = activityName,
+                StartedAt = new DateTime(2020, 01, 01)
+            });
+
+            _dbContext.AssessmentData.Add(new AssessmentData
+            {
+                ProcessId = 123,
+                EffectiveStartDate = new DateTime(2020, 05, 01),
+                ReceiptDate = new DateTime(2020, 05, 01)
+            });
+
+            await _dbContext.SaveChangesAsync();
+
+            await _taskInformationModel.OnGetAsync(ProcessId, activityName);
+
+            Assert.AreEqual(new DateTime(2020, 05, 01).ToShortDateString(),
+                _taskInformationModel.EffectiveReceiptDate);
+        }
+
+        [TestCase("Review")]
+        [TestCase("Assess")]
+        [TestCase("Verify")]
+        public async Task Test_EffectiveReceiptDate_is_set_to_NA_when_calling_onGet_with_no_EffectiveStartDate(string activityName)
+        {
+            _dbContext.DbAssessmentReviewData.Add(new DbAssessmentReviewData()
+            {
+                ProcessId = ProcessId,
+                TaskType = "Simple"
+            });
+
+            _dbContext.DbAssessmentAssessData.Add(new DbAssessmentAssessData()
+            {
+                ProcessId = ProcessId,
+                TaskType = "Simple"
+            });
+
+            _dbContext.DbAssessmentVerifyData.Add(new DbAssessmentVerifyData()
+            {
+                ProcessId = ProcessId,
+                TaskType = "Simple"
+            });
+
+            _dbContext.WorkflowInstance.Add(new WorkflowInstance
+            {
+                ProcessId = 123,
+                ActivityName = activityName,
+                StartedAt = new DateTime(2020, 01, 01)
+            });
+
+            _dbContext.AssessmentData.Add(new AssessmentData
+            {
+                ProcessId = 123,
+                ReceiptDate = new DateTime(2020, 05, 01)
+            });
+
+            await _dbContext.SaveChangesAsync();
+
+            await _taskInformationModel.OnGetAsync(ProcessId, activityName);
+
+            Assert.AreEqual("N/A",
+                _taskInformationModel.EffectiveReceiptDate);
+        }
+
+        [TestCase("Review")]
+        [TestCase("Assess")]
+        [TestCase("Verify")]
+        public async Task Test_DmEndDate_is_set_to_NA_when_calling_onGet_with_no_EffectiveStartDate(string activityName)
+        {
+            _dbContext.DbAssessmentReviewData.Add(new DbAssessmentReviewData()
+            {
+                ProcessId = ProcessId,
+                TaskType = "Simple"
+            });
+
+            _dbContext.DbAssessmentAssessData.Add(new DbAssessmentAssessData()
+            {
+                ProcessId = ProcessId,
+                TaskType = "Simple"
+            });
+
+            _dbContext.DbAssessmentVerifyData.Add(new DbAssessmentVerifyData()
+            {
+                ProcessId = ProcessId,
+                TaskType = "Simple"
+            });
+
+            _dbContext.WorkflowInstance.Add(new WorkflowInstance
+            {
+                ProcessId = 123,
+                ActivityName = activityName,
+                StartedAt = new DateTime(2020, 01, 01)
+            });
+
+            _dbContext.AssessmentData.Add(new AssessmentData
+            {
+                ProcessId = 123,
+                ReceiptDate = new DateTime(2020, 05, 01)
+            });
+
+            await _dbContext.SaveChangesAsync();
+
+            await _taskInformationModel.OnGetAsync(ProcessId, activityName);
+
+            Assert.AreEqual("N/A",
+                _taskInformationModel.DmEndDate);
+        }
+
+
+        [TestCase("Review")]
+        [TestCase("Assess")]
+        [TestCase("Verify")]
+        public async Task Test_DmEndDate_is_set_to_NA_when_calling_onGet_with_no_TaskData(string activityName)
+        {
+           _dbContext.WorkflowInstance.Add(new WorkflowInstance
+            {
+                ProcessId = 123,
+                ActivityName = activityName,
+                StartedAt = new DateTime(2020, 01, 01)
+            });
+
+            _dbContext.AssessmentData.Add(new AssessmentData
+            {
+                ProcessId = 123,
+                EffectiveStartDate = new DateTime(2020, 05, 01),
+                ReceiptDate = new DateTime(2020, 05, 01)
+            });
+
+            await _dbContext.SaveChangesAsync();
+
+            await _taskInformationModel.OnGetAsync(ProcessId, activityName);
+
+            Assert.AreEqual("N/A",
+                _taskInformationModel.DmEndDate);
+        }
+
+
+        [TestCase("Review")]
+        [TestCase("Assess")]
+        [TestCase("Verify")]
+        public async Task Test_DmEndDate_is_set_to_NA_when_calling_onGet_with_no_TaskData_and_no_EffectiveStartDate(string activityName)
+        {
+            _dbContext.WorkflowInstance.Add(new WorkflowInstance
+            {
+                ProcessId = 123,
+                ActivityName = activityName,
+                StartedAt = new DateTime(2020, 01, 01)
+            });
+
+            _dbContext.AssessmentData.Add(new AssessmentData
+            {
+                ProcessId = 123,
+                ReceiptDate = new DateTime(2020, 05, 01)
+            });
+
+            await _dbContext.SaveChangesAsync();
+
+            await _taskInformationModel.OnGetAsync(ProcessId, activityName);
+
+            Assert.AreEqual("N/A",
+                _taskInformationModel.DmEndDate);
+        }
+
+        [TestCase("Review")]
+        [TestCase("Assess")]
+        [TestCase("Verify")]
+        public async Task Test_ExternalEndDate_is_set_to_NA_when_calling_onGet_with_no_EffectiveStartDate(string activityName)
+        {
+            _dbContext.DbAssessmentReviewData.Add(new DbAssessmentReviewData()
+            {
+                ProcessId = ProcessId,
+                TaskType = "Simple"
+            });
+
+            _dbContext.DbAssessmentAssessData.Add(new DbAssessmentAssessData()
+            {
+                ProcessId = ProcessId,
+                TaskType = "Simple"
+            });
+
+            _dbContext.DbAssessmentVerifyData.Add(new DbAssessmentVerifyData()
+            {
+                ProcessId = ProcessId,
+                TaskType = "Simple"
+            });
+
+            _dbContext.WorkflowInstance.Add(new WorkflowInstance
+            {
+                ProcessId = 123,
+                ActivityName = activityName,
+                StartedAt = new DateTime(2020, 01, 01)
+            });
+
+            _dbContext.AssessmentData.Add(new AssessmentData
+            {
+                ProcessId = 123,
+                ReceiptDate = new DateTime(2020, 05, 01)
+            });
+
+            await _dbContext.SaveChangesAsync();
+
+            await _taskInformationModel.OnGetAsync(ProcessId, activityName);
+
+            Assert.AreEqual("N/A",
+                _taskInformationModel.ExternalEndDate);
+        }
+
     }
 }

--- a/src/Portal/Portal.UnitTests/TaskInformationTests.cs
+++ b/src/Portal/Portal.UnitTests/TaskInformationTests.cs
@@ -152,12 +152,12 @@ namespace Portal.UnitTests
 
             if (taskType == "Simple" || activityName == "Review")
             {
-                Assert.AreEqual(new DateTime(2020, 05, 15),
+                Assert.AreEqual(new DateTime(2020, 05, 15).ToShortDateString(),
                     _taskInformationModel.DmEndDate);
             }
             else if (taskType == "LTA")
             {
-                Assert.AreEqual(new DateTime(2020, 07, 12),
+                Assert.AreEqual(new DateTime(2020, 07, 12).ToShortDateString(),
                     _taskInformationModel.DmEndDate);
             }
             

--- a/src/Portal/Portal.UnitTests/TaskInformationTests.cs
+++ b/src/Portal/Portal.UnitTests/TaskInformationTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using FakeItEasy;
 using Microsoft.EntityFrameworkCore;
@@ -116,37 +117,14 @@ namespace Portal.UnitTests
         [TestCase("Verify", "LTA")]
         public async Task Test_DmEndDate_is_set_when_calling_onGet(string activityName, string taskType)
         {
-            _dbContext.DbAssessmentReviewData.Add(new DbAssessmentReviewData()
-            {
-                ProcessId = ProcessId,
-                TaskType = taskType
-            });
+            await SetupSupportingTestData(activityName);
 
-            _dbContext.DbAssessmentAssessData.Add(new DbAssessmentAssessData()
-            {
-                ProcessId = ProcessId,
-                TaskType = taskType
-            });
+            _dbContext.DbAssessmentReviewData.First(ad => ad.ProcessId == ProcessId).TaskType = taskType;
+            _dbContext.DbAssessmentAssessData.First(ad => ad.ProcessId == ProcessId).TaskType = taskType;
+            _dbContext.DbAssessmentVerifyData.First(ad => ad.ProcessId == ProcessId).TaskType = taskType;
 
-            _dbContext.DbAssessmentVerifyData.Add(new DbAssessmentVerifyData()
-            {
-                ProcessId = ProcessId,
-                TaskType = taskType
-            });
-
-            _dbContext.WorkflowInstance.Add(new WorkflowInstance
-            {
-                ProcessId = 123,
-                ActivityName = activityName
-            });
-
-            _dbContext.AssessmentData.Add(new AssessmentData
-            {
-                ProcessId = 123,
-                EffectiveStartDate = new DateTime(2020, 05, 01)
-            });
-
-            await _dbContext.SaveChangesAsync();
+            _dbContext.AssessmentData.First(ad => ad.ProcessId == ProcessId).EffectiveStartDate =
+                new DateTime(2020, 05, 01);
 
             await _taskInformationModel.OnGetAsync(ProcessId, activityName);
 
@@ -168,36 +146,12 @@ namespace Portal.UnitTests
         [TestCase("Verify")]
         public async Task Test_ExternalEndDate_is_set_when_calling_onGet(string activityName)
         {
-            _dbContext.DbAssessmentReviewData.Add(new DbAssessmentReviewData()
-            {
-                ProcessId = ProcessId,
-                TaskType = "Simple"
-            });
+            await SetupSupportingTestData(activityName);
 
-            _dbContext.DbAssessmentAssessData.Add(new DbAssessmentAssessData()
-            {
-                ProcessId = ProcessId,
-                TaskType = "Simple"
-            });
+            _dbContext.AssessmentData.First(ad => ad.ProcessId == ProcessId).EffectiveStartDate =
+                new DateTime(2020, 05, 01);
 
-            _dbContext.DbAssessmentVerifyData.Add(new DbAssessmentVerifyData()
-            {
-                ProcessId = ProcessId,
-                TaskType = "Simple"
-            });
-
-            _dbContext.WorkflowInstance.Add(new WorkflowInstance
-            {
-                ProcessId = 123,
-                ActivityName = activityName
-            });
-
-            _dbContext.AssessmentData.Add(new AssessmentData
-            {
-                ProcessId = 123,
-                EffectiveStartDate = new DateTime(2020, 05, 01),
-                ReceiptDate = new DateTime(2020, 05, 01)
-            });
+            _dbContext.AssessmentData.First(ad => ad.ProcessId == ProcessId).ReceiptDate = new DateTime(2020, 05, 01);
 
             await _dbContext.SaveChangesAsync();
 
@@ -212,37 +166,12 @@ namespace Portal.UnitTests
         [TestCase("Verify")]
         public async Task Test_DmReceiptDate_is_set_when_calling_onGet(string activityName)
         {
-            _dbContext.DbAssessmentReviewData.Add(new DbAssessmentReviewData()
-            {
-                ProcessId = ProcessId,
-                TaskType = "Simple"
-            });
+            await SetupSupportingTestData(activityName);
 
-            _dbContext.DbAssessmentAssessData.Add(new DbAssessmentAssessData()
-            {
-                ProcessId = ProcessId,
-                TaskType = "Simple"
-            });
+            _dbContext.AssessmentData.First(ad => ad.ProcessId == ProcessId).EffectiveStartDate =
+                new DateTime(2020, 05, 01);
 
-            _dbContext.DbAssessmentVerifyData.Add(new DbAssessmentVerifyData()
-            {
-                ProcessId = ProcessId,
-                TaskType = "Simple"
-            });
-
-            _dbContext.WorkflowInstance.Add(new WorkflowInstance
-            {
-                ProcessId = 123,
-                ActivityName = activityName,
-                StartedAt = new DateTime(2020, 01, 01)
-            });
-
-            _dbContext.AssessmentData.Add(new AssessmentData
-            {
-                ProcessId = 123,
-                EffectiveStartDate = new DateTime(2020, 05, 01),
-                ReceiptDate = new DateTime(2020, 05, 01)
-            });
+            _dbContext.AssessmentData.First(ad => ad.ProcessId == ProcessId).ReceiptDate = new DateTime(2020, 05, 01);
 
             await _dbContext.SaveChangesAsync();
 
@@ -257,37 +186,12 @@ namespace Portal.UnitTests
         [TestCase("Verify")]
         public async Task Test_EffectiveReceiptDate_is_set_when_calling_onGet(string activityName)
         {
-            _dbContext.DbAssessmentReviewData.Add(new DbAssessmentReviewData()
-            {
-                ProcessId = ProcessId,
-                TaskType = "Simple"
-            });
+            await SetupSupportingTestData(activityName);
 
-            _dbContext.DbAssessmentAssessData.Add(new DbAssessmentAssessData()
-            {
-                ProcessId = ProcessId,
-                TaskType = "Simple"
-            });
+            _dbContext.AssessmentData.First(ad => ad.ProcessId == ProcessId).EffectiveStartDate =
+                new DateTime(2020, 05, 01);
 
-            _dbContext.DbAssessmentVerifyData.Add(new DbAssessmentVerifyData()
-            {
-                ProcessId = ProcessId,
-                TaskType = "Simple"
-            });
-
-            _dbContext.WorkflowInstance.Add(new WorkflowInstance
-            {
-                ProcessId = 123,
-                ActivityName = activityName,
-                StartedAt = new DateTime(2020, 01, 01)
-            });
-
-            _dbContext.AssessmentData.Add(new AssessmentData
-            {
-                ProcessId = 123,
-                EffectiveStartDate = new DateTime(2020, 05, 01),
-                ReceiptDate = new DateTime(2020, 05, 01)
-            });
+            _dbContext.AssessmentData.First(ad => ad.ProcessId == ProcessId).ReceiptDate = new DateTime(2020, 05, 01);
 
             await _dbContext.SaveChangesAsync();
 
@@ -302,36 +206,9 @@ namespace Portal.UnitTests
         [TestCase("Verify")]
         public async Task Test_EffectiveReceiptDate_is_set_to_NA_when_calling_onGet_with_no_EffectiveStartDate(string activityName)
         {
-            _dbContext.DbAssessmentReviewData.Add(new DbAssessmentReviewData()
-            {
-                ProcessId = ProcessId,
-                TaskType = "Simple"
-            });
+            await SetupSupportingTestData(activityName);
 
-            _dbContext.DbAssessmentAssessData.Add(new DbAssessmentAssessData()
-            {
-                ProcessId = ProcessId,
-                TaskType = "Simple"
-            });
-
-            _dbContext.DbAssessmentVerifyData.Add(new DbAssessmentVerifyData()
-            {
-                ProcessId = ProcessId,
-                TaskType = "Simple"
-            });
-
-            _dbContext.WorkflowInstance.Add(new WorkflowInstance
-            {
-                ProcessId = 123,
-                ActivityName = activityName,
-                StartedAt = new DateTime(2020, 01, 01)
-            });
-
-            _dbContext.AssessmentData.Add(new AssessmentData
-            {
-                ProcessId = 123,
-                ReceiptDate = new DateTime(2020, 05, 01)
-            });
+            _dbContext.AssessmentData.First(ad => ad.ProcessId == ProcessId).ReceiptDate = new DateTime(2020, 05, 01);
 
             await _dbContext.SaveChangesAsync();
 
@@ -346,36 +223,9 @@ namespace Portal.UnitTests
         [TestCase("Verify")]
         public async Task Test_DmEndDate_is_set_to_NA_when_calling_onGet_with_no_EffectiveStartDate(string activityName)
         {
-            _dbContext.DbAssessmentReviewData.Add(new DbAssessmentReviewData()
-            {
-                ProcessId = ProcessId,
-                TaskType = "Simple"
-            });
+            await SetupSupportingTestData(activityName);
 
-            _dbContext.DbAssessmentAssessData.Add(new DbAssessmentAssessData()
-            {
-                ProcessId = ProcessId,
-                TaskType = "Simple"
-            });
-
-            _dbContext.DbAssessmentVerifyData.Add(new DbAssessmentVerifyData()
-            {
-                ProcessId = ProcessId,
-                TaskType = "Simple"
-            });
-
-            _dbContext.WorkflowInstance.Add(new WorkflowInstance
-            {
-                ProcessId = 123,
-                ActivityName = activityName,
-                StartedAt = new DateTime(2020, 01, 01)
-            });
-
-            _dbContext.AssessmentData.Add(new AssessmentData
-            {
-                ProcessId = 123,
-                ReceiptDate = new DateTime(2020, 05, 01)
-            });
+            _dbContext.AssessmentData.First(ad => ad.ProcessId == ProcessId).ReceiptDate = new DateTime(2020, 05, 01);
 
             await _dbContext.SaveChangesAsync();
 
@@ -391,7 +241,7 @@ namespace Portal.UnitTests
         [TestCase("Verify")]
         public async Task Test_DmEndDate_is_set_to_NA_when_calling_onGet_with_no_TaskData(string activityName)
         {
-           _dbContext.WorkflowInstance.Add(new WorkflowInstance
+            _dbContext.WorkflowInstance.Add(new WorkflowInstance
             {
                 ProcessId = 123,
                 ActivityName = activityName,
@@ -445,6 +295,20 @@ namespace Portal.UnitTests
         [TestCase("Verify")]
         public async Task Test_ExternalEndDate_is_set_to_NA_when_calling_onGet_with_no_EffectiveStartDate(string activityName)
         {
+            await SetupSupportingTestData(activityName);
+            
+            _dbContext.AssessmentData.First(ad => ad.ProcessId == ProcessId).ReceiptDate = new DateTime(2020, 05, 01);
+
+            await _dbContext.SaveChangesAsync();
+
+            await _taskInformationModel.OnGetAsync(ProcessId, activityName);
+
+            Assert.AreEqual("N/A",
+                _taskInformationModel.ExternalEndDate);
+        }
+
+        private async Task SetupSupportingTestData(string activityName)
+        {
             _dbContext.DbAssessmentReviewData.Add(new DbAssessmentReviewData()
             {
                 ProcessId = ProcessId,
@@ -472,17 +336,10 @@ namespace Portal.UnitTests
 
             _dbContext.AssessmentData.Add(new AssessmentData
             {
-                ProcessId = 123,
-                ReceiptDate = new DateTime(2020, 05, 01)
+                ProcessId = 123
             });
 
             await _dbContext.SaveChangesAsync();
-
-            await _taskInformationModel.OnGetAsync(ProcessId, activityName);
-
-            Assert.AreEqual("N/A",
-                _taskInformationModel.ExternalEndDate);
         }
-
     }
 }

--- a/src/Portal/Portal/Configuration/GeneralConfig.cs
+++ b/src/Portal/Portal/Configuration/GeneralConfig.cs
@@ -25,6 +25,7 @@ namespace Portal.Configuration
         public string SourceDocumentWriteableFolderName { get; set; }
         public int UsagesSelectionPageLength { get; set; }
         public int SourcesSelectionPageLength { get; set; }
+        public int ExternalEndDateDays { get; set; }
 
         public string TeamsAsCsv { get; set; }
         public string TeamsUnassigned { get; set; }

--- a/src/Portal/Portal/Pages/DbAssessment/_EditDatabase.cshtml
+++ b/src/Portal/Portal/Pages/DbAssessment/_EditDatabase.cshtml
@@ -101,8 +101,8 @@
                         <table id="usagesSelection" class="table-striped" style="width: 100%">
                             <thead>
                                 <tr>
-                                    <th style="width: 300px;"><span class="screen-reader-only">Data Layer Names</span></th> @*TODO: Admin task to get exact wording*@
-                                    <th><span class="screen-reader-only">Select Data Layers</span></th> @*TODO: Admin task to get exact wording*@
+                                    <th style="width: 300px;"><span class="screen-reader-only">Data Layer Names</span></th>
+                                    <th><span class="screen-reader-only">Select Data Layers</span></th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -150,8 +150,8 @@
                         <table id="sourcesSelection" class="table-striped" style="width: 100%">
                             <thead>
                                 <tr>
-                                    <th style="width: 300px;"><span class="screen-reader-only">Source Names</span></th> @*TODO: Admin task to get exact wording*@
-                                    <th><span class="screen-reader-only">Select Sources</span></th> @*TODO: Admin task to get exact wording*@
+                                    <th style="width: 300px;"><span class="screen-reader-only">Source Names</span></th>
+                                    <th><span class="screen-reader-only">Select Sources</span></th>
                                 </tr>
                             </thead>
                             <tbody>

--- a/src/Portal/Portal/Pages/DbAssessment/_TaskInformation.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_TaskInformation.cshtml.cs
@@ -129,7 +129,9 @@ namespace Portal.Pages.DbAssessment
                 Team = string.IsNullOrWhiteSpace(assessmentData.TeamDistributedTo) ? "" : assessmentData.TeamDistributedTo;
 
                 DmEndDate = _dmEndDateCalculator.CalculateDmEndDate(assessmentData.EffectiveStartDate.Value,
-                                taskData.TaskType, activityName).dmEndDate;
+                                taskData.TaskType, activityName).dmEndDate; //TODO: Check nullability of TaskType.
+
+                ExternalEndDate = EffectiveReceiptDate.AddDays(_generalConfig.Value.ExternalEndDateDays);
 
             }
         }

--- a/src/Portal/Portal/Pages/DbAssessment/_TaskInformation.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_TaskInformation.cshtml.cs
@@ -33,8 +33,7 @@ namespace Portal.Pages.DbAssessment
         public int ProcessId { get; set; }
 
         [DisplayName("DM End Date:")]
-        [DisplayFormat(DataFormatString = "{0:d}")]
-        public DateTime DmEndDate { get; set; }
+        public string DmEndDate { get; set; }
 
         [DisplayName("DM Receipt Date:")]
         [DisplayFormat(DataFormatString = "{0:d}")]
@@ -128,8 +127,8 @@ namespace Portal.Pages.DbAssessment
                 EffectiveReceiptDate = assessmentData.ReceiptDate;
                 Team = string.IsNullOrWhiteSpace(assessmentData.TeamDistributedTo) ? "" : assessmentData.TeamDistributedTo;
 
-                DmEndDate = _dmEndDateCalculator.CalculateDmEndDate(assessmentData.EffectiveStartDate.Value,
-                                taskData.TaskType, activityName).dmEndDate; //TODO: Check nullability of TaskType.
+                DmEndDate = taskData != null ? _dmEndDateCalculator.CalculateDmEndDate(assessmentData.EffectiveStartDate.Value,
+                                taskData.TaskType, activityName).dmEndDate.ToShortDateString() : "N/A";
 
                 ExternalEndDate = EffectiveReceiptDate.AddDays(_generalConfig.Value.ExternalEndDateDays);
 

--- a/src/Portal/Portal/Pages/DbAssessment/_TaskInformation.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_TaskInformation.cshtml.cs
@@ -129,7 +129,7 @@ namespace Portal.Pages.DbAssessment
                 EffectiveReceiptDate = assessmentData.EffectiveStartDate != null ? assessmentData.EffectiveStartDate.Value.ToShortDateString() : "N/A" ;
                 Team = string.IsNullOrWhiteSpace(assessmentData.TeamDistributedTo) ? "" : assessmentData.TeamDistributedTo;
 
-                DmEndDate = taskData != null ? _dmEndDateCalculator.CalculateDmEndDate(assessmentData.EffectiveStartDate.Value,
+                DmEndDate = taskData != null && assessmentData.EffectiveStartDate != null ? _dmEndDateCalculator.CalculateDmEndDate(assessmentData.EffectiveStartDate.Value,
                                 taskData.TaskType, activityName).dmEndDate.ToShortDateString() : "N/A";
 
                 ExternalEndDate = assessmentData.EffectiveStartDate != null ?


### PR DESCRIPTION
Fix display of various dates in the Task Information section, and display N/A if the date is NULL:

- Use existing calculator for DM End Date
- Set Effective Receipt Date, DM Receipt Date and External End Date
- Unit tests to ensure dates are set correctly, and N/A is displayed where applicable