### PR TITLE
Features/add server side protection for read only tasks

### DIFF
--- a/src/Databases/WorkflowDatabase.EF/Models/WorkflowInstance.cs
+++ b/src/Databases/WorkflowDatabase.EF/Models/WorkflowInstance.cs
@@ -13,18 +13,6 @@ namespace WorkflowDatabase.EF.Models
         public DateTime ActivityChangedAt { get; set; }
         public DateTime StartedAt { get; set; }
         public string Status { get; set; }
-        public bool IsReadOnly
-        {
-            get
-            {
-                if (Status == WorkflowStatus.Terminated.ToString() ||
-                    Status == WorkflowStatus.Completed.ToString())
-                {
-                    return true;
-                }
-                return false;
-            }
-        }
 
         public virtual List<Comment> Comments { get; set; }
         public virtual AssessmentData AssessmentData { get; set; }

--- a/src/Databases/WorkflowDatabase.EF/WorkflowDbContext.cs
+++ b/src/Databases/WorkflowDatabase.EF/WorkflowDbContext.cs
@@ -96,7 +96,6 @@ namespace WorkflowDatabase.EF
                 .HasForeignKey<CarisProjectDetails>(p => p.ProcessId);
 
             modelBuilder.Entity<WorkflowInstance>().Property(p => p.ActivityChangedAt).HasColumnType("date");
-            modelBuilder.Entity<WorkflowInstance>().Ignore(w => w.IsReadOnly);
             modelBuilder.Entity<PrimaryDocumentStatus>().Ignore(l => l.ContentServiceUri);
             modelBuilder.Entity<LinkedDocument>().Ignore(l => l.ContentServiceUri);
             modelBuilder.Entity<DatabaseDocumentStatus>().Ignore(l => l.ContentServiceUri);

--- a/src/Portal/Portal.UnitTests/ReviewTests.cs
+++ b/src/Portal/Portal.UnitTests/ReviewTests.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using Portal.Auth;
+using Portal.BusinessLogic;
 using Portal.Helpers;
 using Portal.HttpClients;
 using Portal.Pages.DbAssessment;
@@ -25,6 +26,7 @@ namespace Portal.UnitTests
         private HpdDbContext _hpDbContext;
         private ReviewModel _reviewModel;
         private int ProcessId { get; set; }
+        private IWorkflowBusinessLogicService _fakeWorkflowBusinessLogicService;
         private IAdDirectoryService _fakeAdDirectoryService;
         private IPortalUserDbService _fakePortalUserDbService;
         private ILogger<ReviewModel> _fakeLogger;
@@ -46,6 +48,7 @@ namespace Portal.UnitTests
 
             _dbContext = new WorkflowDbContext(dbContextOptions);
 
+            _fakeWorkflowBusinessLogicService = A.Fake<IWorkflowBusinessLogicService>();
             _fakeWorkflowServiceApiClient = A.Fake<IWorkflowServiceApiClient>();
             _fakeEventServiceApiClient = A.Fake<IEventServiceApiClient>();
             _commentsHelper = new CommentsHelper(_dbContext);
@@ -101,7 +104,7 @@ namespace Portal.UnitTests
 
             _fakepageValidationHelper = A.Fake<IPageValidationHelper>();
 
-            _reviewModel = new ReviewModel(_dbContext, _fakeDataServiceApiClient, _fakeWorkflowServiceApiClient, _fakeEventServiceApiClient,
+            _reviewModel = new ReviewModel(_dbContext, _fakeWorkflowBusinessLogicService, _fakeDataServiceApiClient, _fakeWorkflowServiceApiClient, _fakeEventServiceApiClient,
                 _fakeCommentsHelper, _fakeAdDirectoryService, _fakeLogger, _pageValidationHelper);
         }
 
@@ -296,7 +299,7 @@ namespace Portal.UnitTests
 
             var primaryAssignTaskNote = "Testing primary";
 
-            _reviewModel = new ReviewModel(_dbContext, null, _fakeWorkflowServiceApiClient,
+            _reviewModel = new ReviewModel(_dbContext, _fakeWorkflowBusinessLogicService, null, _fakeWorkflowServiceApiClient,
                 _fakeEventServiceApiClient, _fakeCommentsHelper, _fakeAdDirectoryService, _fakeLogger,
                 _fakepageValidationHelper)
             {
@@ -687,7 +690,7 @@ namespace Portal.UnitTests
         [Test]
         public async Task Test_That_Setting_Task_To_On_Hold_Creates_A_Row()
         {
-            _reviewModel = new ReviewModel(_dbContext, null, _fakeWorkflowServiceApiClient, _fakeEventServiceApiClient, _fakeCommentsHelper, _fakeAdDirectoryService,
+            _reviewModel = new ReviewModel(_dbContext, _fakeWorkflowBusinessLogicService, null, _fakeWorkflowServiceApiClient, _fakeEventServiceApiClient, _fakeCommentsHelper, _fakeAdDirectoryService,
                 _fakeLogger, _fakepageValidationHelper);
 
             var primaryAssignTaskNote = "Testing primary";
@@ -731,7 +734,7 @@ namespace Portal.UnitTests
         [Test]
         public async Task Test_That_Setting_Task_To_Off_Hold_Updates_Existing_Row()
         {
-            _reviewModel = new ReviewModel(_dbContext, null, _fakeWorkflowServiceApiClient, _fakeEventServiceApiClient, _fakeCommentsHelper, _fakeAdDirectoryService,
+            _reviewModel = new ReviewModel(_dbContext, _fakeWorkflowBusinessLogicService, null, _fakeWorkflowServiceApiClient, _fakeEventServiceApiClient, _fakeCommentsHelper, _fakeAdDirectoryService,
                 _fakeLogger, _fakepageValidationHelper);
 
             var primaryAssignTaskNote = "Testing primary";
@@ -772,7 +775,7 @@ namespace Portal.UnitTests
         [Test]
         public async Task Test_That_Setting_Task_To_On_Hold_Adds_Comment()
         {
-            _reviewModel = new ReviewModel(_dbContext, null, _fakeWorkflowServiceApiClient, _fakeEventServiceApiClient, _commentsHelper, _fakeAdDirectoryService,
+            _reviewModel = new ReviewModel(_dbContext, _fakeWorkflowBusinessLogicService, null, _fakeWorkflowServiceApiClient, _fakeEventServiceApiClient, _commentsHelper, _fakeAdDirectoryService,
                 _fakeLogger, _fakepageValidationHelper);
 
             var primaryAssignTaskNote = "Testing primary";
@@ -816,7 +819,7 @@ namespace Portal.UnitTests
         [Test]
         public async Task Test_That_Setting_Task_To_Off_Hold_Adds_Comment()
         {
-            _reviewModel = new ReviewModel(_dbContext, null, _fakeWorkflowServiceApiClient, _fakeEventServiceApiClient, _commentsHelper, _fakeAdDirectoryService,
+            _reviewModel = new ReviewModel(_dbContext, _fakeWorkflowBusinessLogicService, null, _fakeWorkflowServiceApiClient, _fakeEventServiceApiClient, _commentsHelper, _fakeAdDirectoryService,
                 _fakeLogger, _fakepageValidationHelper);
 
             var primaryAssignTaskNote = "Testing primary";

--- a/src/Portal/Portal.UnitTests/VerifyTests.cs
+++ b/src/Portal/Portal.UnitTests/VerifyTests.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
 using Portal.Auth;
+using Portal.BusinessLogic;
 using Portal.Configuration;
 using Portal.Helpers;
 using Portal.HttpClients;
@@ -31,6 +32,7 @@ namespace Portal.UnitTests
         private HpdDbContext _hpDbContext;
         private VerifyModel _verifyModel;
         private int ProcessId { get; set; }
+        private IWorkflowBusinessLogicService _fakeWorkflowBusinessLogicService;
         private ILogger<VerifyModel> _fakeLogger;
         private IWorkflowServiceApiClient _fakeWorkflowServiceApiClient;
         private IEventServiceApiClient _fakeEventServiceApiClient;
@@ -53,6 +55,7 @@ namespace Portal.UnitTests
 
             _dbContext = new WorkflowDbContext(dbContextOptions);
 
+            _fakeWorkflowBusinessLogicService = A.Fake<IWorkflowBusinessLogicService>();
             _fakeWorkflowServiceApiClient = A.Fake<IWorkflowServiceApiClient>();
             _fakeEventServiceApiClient = A.Fake<IEventServiceApiClient>();
             _fakePcpEventServiceApiClient = A.Fake<IPcpEventServiceApiClient>();
@@ -113,8 +116,17 @@ namespace Portal.UnitTests
 
             _pageValidationHelper = new PageValidationHelper(_dbContext, _hpDbContext, _fakeAdDirectoryService, _fakePortalUserDbService);
 
-            _verifyModel = new VerifyModel(_dbContext, _fakeWorkflowServiceApiClient, _fakeEventServiceApiClient,
-                _fakeCommentsHelper, _fakeAdDirectoryService, _fakeLogger, _pageValidationHelper, _fakeCarisProjectHelper, _generalConfig, _fakePcpEventServiceApiClient);
+            _verifyModel = new VerifyModel(_dbContext,
+                _fakeWorkflowBusinessLogicService,
+                _fakeWorkflowServiceApiClient,
+                _fakeEventServiceApiClient,
+                _fakeCommentsHelper,
+                _fakeAdDirectoryService,
+                _fakeLogger,
+                _pageValidationHelper,
+                _fakeCarisProjectHelper,
+                _generalConfig,
+                _fakePcpEventServiceApiClient);
         }
 
         [TearDown]
@@ -584,7 +596,7 @@ namespace Portal.UnitTests
             _pageValidationHelper = A.Fake<IPageValidationHelper>();
 
 
-            _verifyModel = new VerifyModel(_dbContext, _fakeWorkflowServiceApiClient, _fakeEventServiceApiClient,
+            _verifyModel = new VerifyModel(_dbContext, _fakeWorkflowBusinessLogicService, _fakeWorkflowServiceApiClient, _fakeEventServiceApiClient,
                 _fakeCommentsHelper, _fakeAdDirectoryService, _fakeLogger, _pageValidationHelper, _fakeCarisProjectHelper, _generalConfig, _fakePcpEventServiceApiClient);
 
             A.CallTo(() => _fakeWorkflowServiceApiClient.ProgressWorkflowInstance(A<int>.Ignored, A<string>.Ignored,
@@ -631,7 +643,7 @@ namespace Portal.UnitTests
         [Test]
         public async Task Test_That_Setting_Task_To_On_Hold_Creates_A_Row()
         {
-            _verifyModel = new VerifyModel(_dbContext, _fakeWorkflowServiceApiClient, _fakeEventServiceApiClient, _fakeCommentsHelper, _fakeAdDirectoryService,
+            _verifyModel = new VerifyModel(_dbContext, _fakeWorkflowBusinessLogicService, _fakeWorkflowServiceApiClient, _fakeEventServiceApiClient, _fakeCommentsHelper, _fakeAdDirectoryService,
                 _fakeLogger, _fakePageValidationHelper, _fakeCarisProjectHelper, _generalConfig, _fakePcpEventServiceApiClient);
 
             A.CallTo(() => _fakePortalUserDbService.ValidateUserAsync(A<string>.Ignored))
@@ -663,7 +675,7 @@ namespace Portal.UnitTests
         [Test]
         public async Task Test_That_Setting_Task_To_Off_Hold_Updates_Existing_Row()
         {
-            _verifyModel = new VerifyModel(_dbContext, _fakeWorkflowServiceApiClient, _fakeEventServiceApiClient, _fakeCommentsHelper, _fakeAdDirectoryService,
+            _verifyModel = new VerifyModel(_dbContext, _fakeWorkflowBusinessLogicService, _fakeWorkflowServiceApiClient, _fakeEventServiceApiClient, _fakeCommentsHelper, _fakeAdDirectoryService,
                 _fakeLogger, _fakePageValidationHelper, _fakeCarisProjectHelper, _generalConfig, _fakePcpEventServiceApiClient);
 
             A.CallTo(() => _fakePortalUserDbService.ValidateUserAsync(A<string>.Ignored))
@@ -704,7 +716,7 @@ namespace Portal.UnitTests
         [Test]
         public async Task Test_That_Setting_Task_To_On_Hold_Adds_Comment()
         {
-            _verifyModel = new VerifyModel(_dbContext, _fakeWorkflowServiceApiClient, _fakeEventServiceApiClient, _commentsHelper, _fakeAdDirectoryService,
+            _verifyModel = new VerifyModel(_dbContext, _fakeWorkflowBusinessLogicService, _fakeWorkflowServiceApiClient, _fakeEventServiceApiClient, _commentsHelper, _fakeAdDirectoryService,
                 _fakeLogger, _fakePageValidationHelper, _fakeCarisProjectHelper, _generalConfig, _fakePcpEventServiceApiClient);
 
             A.CallTo(() => _fakePortalUserDbService.ValidateUserAsync(A<string>.Ignored))
@@ -736,7 +748,7 @@ namespace Portal.UnitTests
         [Test]
         public async Task Test_That_Setting_Task_To_Off_Hold_Adds_Comment()
         {
-            _verifyModel = new VerifyModel(_dbContext, _fakeWorkflowServiceApiClient, _fakeEventServiceApiClient, _commentsHelper, _fakeAdDirectoryService,
+            _verifyModel = new VerifyModel(_dbContext, _fakeWorkflowBusinessLogicService, _fakeWorkflowServiceApiClient, _fakeEventServiceApiClient, _commentsHelper, _fakeAdDirectoryService,
                 _fakeLogger, _fakePageValidationHelper, _fakeCarisProjectHelper, _generalConfig, _fakePcpEventServiceApiClient);
 
             A.CallTo(() => _fakePortalUserDbService.ValidateUserAsync(A<string>.Ignored))

--- a/src/Portal/Portal.UnitTests/WorkflowBusinessLogicServiceTests.cs
+++ b/src/Portal/Portal.UnitTests/WorkflowBusinessLogicServiceTests.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Threading.Tasks;
+using FakeItEasy;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Portal.BusinessLogic;
+using WorkflowDatabase.EF;
+using WorkflowDatabase.EF.Models;
+
+namespace Portal.UnitTests
+{
+    [TestFixture]
+    public class WorkflowBusinessLogicServiceTests
+    {
+        private WorkflowBusinessLogicService _workflowBusinessLogicService;
+        private WorkflowDbContext _dbContext;
+        private ILogger<WorkflowBusinessLogicService> _fakeLogger;
+
+        [SetUp]
+        public void Setup()
+        {
+            var dbContextOptions = new DbContextOptionsBuilder<WorkflowDbContext>()
+                .UseInMemoryDatabase(databaseName: "inmemory")
+                .Options;
+
+            _dbContext = new WorkflowDbContext(dbContextOptions);
+
+            _fakeLogger = A.Fake<ILogger<WorkflowBusinessLogicService>>();
+
+            _workflowBusinessLogicService = new WorkflowBusinessLogicService(
+                _dbContext,
+                _fakeLogger);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _dbContext.Database.EnsureDeleted();
+        }
+
+        [TestCase("Started", ExpectedResult = false)]
+        [TestCase("Updating", ExpectedResult = false)]
+        [TestCase("Unknown", ExpectedResult = false)]
+        [TestCase("Terminated", ExpectedResult = true)]
+        [TestCase("Completed", ExpectedResult = true)]
+        public async Task<bool> Test_WorkflowIsReadOnly_Given_Provided_Status_Then_Returns_ExpectedResult(string taskStatus)
+        {
+            //Arrange
+            var processId = 1;
+            _dbContext.WorkflowInstance.Add(
+            new WorkflowInstance()
+            {
+                ProcessId = processId,
+                Status = taskStatus
+            });
+            await _dbContext.SaveChangesAsync();
+
+            //Act & Assert
+            return await _workflowBusinessLogicService.WorkflowIsReadOnlyAsync(processId);
+        }
+
+        [Test]
+        public void Test_WorkflowIsReadOnly_Given_ProcessId_That_Does_Not_Exist_Then_ArgumentException_Is_Thrown()
+        {
+            //Arrange
+            var processIdThatDoesNotExist = 9999;
+
+            //Act & Assert
+            Assert.ThrowsAsync(typeof(ArgumentException),
+                async () => await _workflowBusinessLogicService.WorkflowIsReadOnlyAsync(processIdThatDoesNotExist)
+            );
+        }
+    }
+}

--- a/src/Portal/Portal/BusinessLogic/IWorkflowBusinessLogicService.cs
+++ b/src/Portal/Portal/BusinessLogic/IWorkflowBusinessLogicService.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Portal.BusinessLogic
+{
+    public interface IWorkflowBusinessLogicService
+    {
+        /// <summary>
+        /// Used to determine if the workflow for the given processId is read only
+        /// </summary>
+        /// <param name="processId">The processId for the workflow</param>
+        /// <returns>True if read only, false if not read only</returns>
+        /// <exception cref="ArgumentException">If workflow for given processId is not found</exception>
+        Task<bool> WorkflowIsReadOnlyAsync(int processId);
+    }
+}

--- a/src/Portal/Portal/BusinessLogic/WorkflowBusinessLogicService.cs
+++ b/src/Portal/Portal/BusinessLogic/WorkflowBusinessLogicService.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using WorkflowDatabase.EF;
+
+namespace Portal.BusinessLogic
+{
+    public class WorkflowBusinessLogicService : IWorkflowBusinessLogicService
+    {
+        private readonly WorkflowDbContext _dbContext;
+        private readonly ILogger<WorkflowBusinessLogicService> _logger;
+
+        public WorkflowBusinessLogicService(WorkflowDbContext dbContext,
+            ILogger<WorkflowBusinessLogicService> logger)
+        {
+            _dbContext = dbContext;
+            _logger = logger;
+        }
+
+        public async Task<bool> WorkflowIsReadOnlyAsync(int processId)
+        {
+            var workflowInstance = await _dbContext.WorkflowInstance
+                .AsNoTracking()
+                .FirstOrDefaultAsync(wi => wi.ProcessId == processId);
+
+            if (workflowInstance == null)
+            {
+                _logger.LogError("ProcessId {ProcessId} does not appear in the WorkflowInstance table", processId);
+                throw new ArgumentException($"{nameof(processId)} {processId} does not appear in the WorkflowInstance table");
+            }
+
+            return workflowInstance.Status == WorkflowStatus.Terminated.ToString() || 
+                   workflowInstance.Status == WorkflowStatus.Completed.ToString();
+        }
+    }
+}

--- a/src/Portal/Portal/Startup.cs
+++ b/src/Portal/Portal/Startup.cs
@@ -24,6 +24,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Microsoft.Graph;
 using Portal.Auth;
+using Portal.BusinessLogic;
 using Portal.Calculators;
 using Portal.Configuration;
 using Portal.Helpers;
@@ -171,6 +172,7 @@ namespace Portal
             services.AddScoped<ISessionFileGenerator, SessionFileGenerator>();
             services.AddScoped<ICarisProjectHelper, CarisProjectHelper>();
             services.AddScoped<ICarisProjectNameGenerator, CarisProjectNameGenerator>();
+            services.AddScoped<IWorkflowBusinessLogicService, WorkflowBusinessLogicService>();
 
             // Use a singleton Microsoft.Graph.HttpProvider to avoid same issues HttpClient once suffered from
             services.AddSingleton<IHttpProvider, HttpProvider>();


### PR DESCRIPTION
### WorkflowDatabase.EF
- Remove WorkflowInstance IsReadOnly property on EF model

### Portal
- Throw ApplicationException in Razor Page Handlers where a user would be making a change to a 'read only' workflow
- Create WorkflowBusinessLogicService (to replace WorkflowInstance IsReadOnly property)
- Replace usages of WorkflowInstance IsReadOnly property with calls to WorkflowBusinessLogicService.WorkflowIsReadOnlyAsync

### Portal.UnitTests
- Add unit tests for WorkflowBusinessLogicService
- Get unit tests to run by adding WorkflowBusinessLogicService wherever necessary