### PR TITLE
Remove db constraint from ProductAction

### DIFF
--- a/src/Databases/WorkflowDatabase.Tests/DatabaseIntegrityTests.cs
+++ b/src/Databases/WorkflowDatabase.Tests/DatabaseIntegrityTests.cs
@@ -310,7 +310,7 @@ namespace WorkflowDatabase.Tests
         }
 
         [Test]
-        public void Ensure_productAction_table_prevents_duplicate_productActiontypeId_for_the_same_processId_due_to_FK()
+        public void Ensure_productAction_table_allows_duplicate_productActiontypeId_for_the_same_processId()
         {
             _dbContext.WorkflowInstance.Add(new WorkflowInstance()
             {
@@ -347,8 +347,7 @@ namespace WorkflowDatabase.Tests
                 Verified = false
             });
 
-            var ex = Assert.Throws<DbUpdateException>(() => _dbContext.SaveChanges());
-            Assert.That(ex.InnerException.Message.Contains("Violation of UNIQUE KEY constraint", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotThrow(() => _dbContext.SaveChanges());
         }
 
         [Test]

--- a/src/Databases/WorkflowDatabase/Tables/ProductAction.sql
+++ b/src/Databases/WorkflowDatabase/Tables/ProductAction.sql
@@ -6,6 +6,5 @@
     [ProductActionTypeId] INT NOT NULL, 
     [Verified] BIT NOT NULL DEFAULT 0, 
     CONSTRAINT [FK_ProductAction_ProductActionType] FOREIGN KEY ([ProductActionTypeId]) REFERENCES [ProductActionType]([ProductActionTypeId]), 
-    CONSTRAINT [FK_ProductAction_WorkflowInstance] FOREIGN KEY ([ProcessId]) REFERENCES [WorkflowInstance]([ProcessId]), 
-    CONSTRAINT [AK_CompositeUnique_ProductAction_ProcessId_ProductActionTypeId] UNIQUE ([ProcessId],[ProductActionTypeId])
+    CONSTRAINT [FK_ProductAction_WorkflowInstance] FOREIGN KEY ([ProcessId]) REFERENCES [WorkflowInstance]([ProcessId])
 )


### PR DESCRIPTION
- Remove unnecessary constraint from the ProductAction table that prevents more than one action type across the same ProcessId