### PR TITLE
Update UKHO.Events package in Portal

### DIFF
--- a/src/Portal/Portal/Portal.csproj
+++ b/src/Portal/Portal/Portal.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.4.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
-    <PackageReference Include="UKHO.Events" Version="1.2.19052.1" />
+    <PackageReference Include="UKHO.Events" Version="1.3.20134.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Portal
- Update UKHO.Events from version 1.2.x (.NET Framework 4.6.2) package, to 1.3.x (.NET Standard 2.1) package