### PR TITLE
Features/improve workflow coord handling of empty assessment data

### DIFF
--- a/src/DataServices/DataServices/Controllers/DataAccessApi.cs
+++ b/src/DataServices/DataServices/Controllers/DataAccessApi.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Data.Common;
 using System.Linq;
@@ -8,6 +9,8 @@ using DataServices.Attributes;
 using DataServices.Connected_Services.SDRADataAccessWebService;
 using DataServices.Models;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Serilog.Context;
 using Swashbuckle.AspNetCore.Annotations;
@@ -202,7 +205,14 @@ namespace DataServices.Controllers
             {
                 _logger.LogInformation("{ApiResource} retrieving AssessmentData");
 
-                var retrievedData = _dbContext.AssessmentData.Where(x => x.SdocId == sdocId.Value).ToList();
+                var retrievedData = await _dbContext.AssessmentData.Where(x => x.SdocId == sdocId.Value).ToListAsync();
+
+                if (retrievedData == null || retrievedData.Count == 0)
+                {
+                    _logger.LogError("{ApiResource} No assessment data found for SdocId: {SdocId}.");
+                    return StatusCode(500, $"No assessment data found for SdocId: {sdocId}");
+                }
+
                 data = retrievedData.Single();
 
                 _logger.LogInformation("{ApiResource} finished retrieving AssessmentData successfully");

--- a/src/DataServices/DataServices/Controllers/DataAccessApi.cs
+++ b/src/DataServices/DataServices/Controllers/DataAccessApi.cs
@@ -205,15 +205,13 @@ namespace DataServices.Controllers
             {
                 _logger.LogInformation("{ApiResource} retrieving AssessmentData");
 
-                var retrievedData = await _dbContext.AssessmentData.Where(x => x.SdocId == sdocId.Value).ToListAsync();
+                data = await _dbContext.AssessmentData.SingleOrDefaultAsync(x => x.SdocId == sdocId.Value);
 
-                if (retrievedData == null || retrievedData.Count == 0)
+                if (data == null)
                 {
                     _logger.LogError("{ApiResource} No assessment data found for SdocId: {SdocId}.");
                     return StatusCode(500, $"No assessment data found for SdocId: {sdocId}");
                 }
-
-                data = retrievedData.Single();
 
                 _logger.LogInformation("{ApiResource} finished retrieving AssessmentData successfully");
             }

--- a/src/Databases/WorkflowDatabase.EF/DocumentLinkType.cs
+++ b/src/Databases/WorkflowDatabase.EF/DocumentLinkType.cs
@@ -1,0 +1,10 @@
+﻿namespace WorkflowDatabase.EF
+{
+    public enum DocumentLinkType 
+    {
+        Unknown,
+        Forward,
+        Backward,
+        Sep
+    }
+}

--- a/src/Portal.TestAutomation.Framework/TestData.cs
+++ b/src/Portal.TestAutomation.Framework/TestData.cs
@@ -18,7 +18,7 @@ namespace Portal.TestAutomation.Framework
 
             _context.AdUser.Add(new AdUser
             {
-                ActiveDirectorySid = rand.Next(1000, 100000).ToString(),
+                UserPrincipalName = userToAdd,
                 DisplayName = userToAdd,
                 LastCheckedDate = DateTime.Today.AddDays(1)
             });

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator.UnitTests/GetBackwardDocumentLinksCommandHandlerTests.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator.UnitTests/GetBackwardDocumentLinksCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Common.Messages.Commands;
 using DataServices.Models;
 using FakeItEasy;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using NServiceBus.Testing;
 using NUnit.Framework;
 using SourceDocumentCoordinator.Handlers;
@@ -16,6 +17,7 @@ namespace SourceDocumentCoordinator.UnitTests
     public class GetBackwardDocumentLinksCommandHandlerTests
     {
         private IDataServiceApiClient _fakeDataServiceApiClient;
+        private ILogger<GetBackwardDocumentLinksCommandHandler> _fakeLogger;
         private TestableMessageHandlerContext _handlerContext;
         private GetBackwardDocumentLinksCommandHandler _handler;
         private WorkflowDbContext _dbContext;
@@ -30,9 +32,10 @@ namespace SourceDocumentCoordinator.UnitTests
             _dbContext = new WorkflowDbContext(dbContextOptions);
 
             _fakeDataServiceApiClient = A.Fake<IDataServiceApiClient>();
+            _fakeLogger = A.Dummy<ILogger<GetBackwardDocumentLinksCommandHandler>>();
 
             _handlerContext = new TestableMessageHandlerContext();
-            _handler = new GetBackwardDocumentLinksCommandHandler(_dbContext, _fakeDataServiceApiClient);
+            _handler = new GetBackwardDocumentLinksCommandHandler(_dbContext, _fakeDataServiceApiClient, _fakeLogger);
         }
 
         [TearDown]

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator.UnitTests/GetBackwardDocumentLinksCommandHandlerTests.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator.UnitTests/GetBackwardDocumentLinksCommandHandlerTests.cs
@@ -85,7 +85,7 @@ namespace SourceDocumentCoordinator.UnitTests
             //Then
             Assert.AreEqual(1, _dbContext.LinkedDocument.Count());
             Assert.AreEqual("RSDRA2019000130872", _dbContext.LinkedDocument.First().RsdraNumber);
-            Assert.AreEqual("Backward", _dbContext.LinkedDocument.First().LinkType);
+            Assert.AreEqual(DocumentLinkType.Backward.ToString(), _dbContext.LinkedDocument.First().LinkType);
         }
 
         [Test]

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator.UnitTests/GetForwardDocumentLinksCommandHandlerTests.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator.UnitTests/GetForwardDocumentLinksCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Common.Messages.Commands;
 using DataServices.Models;
 using FakeItEasy;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using NServiceBus.Testing;
 using NUnit.Framework;
 using SourceDocumentCoordinator.Handlers;
@@ -16,6 +17,7 @@ namespace SourceDocumentCoordinator.UnitTests
     public class GetForwardDocumentLinksCommandHandlerTests
     {
         private IDataServiceApiClient _fakeDataServiceApiClient;
+        private ILogger<GetForwardDocumentLinksCommandHandler> _fakeLogger;
         private TestableMessageHandlerContext _handlerContext;
         private GetForwardDocumentLinksCommandHandler _handler;
         private WorkflowDbContext _dbContext;
@@ -30,9 +32,10 @@ namespace SourceDocumentCoordinator.UnitTests
             _dbContext = new WorkflowDbContext(dbContextOptions);
 
             _fakeDataServiceApiClient = A.Fake<IDataServiceApiClient>();
+            _fakeLogger = A.Dummy<ILogger<GetForwardDocumentLinksCommandHandler>>();
 
             _handlerContext = new TestableMessageHandlerContext();
-            _handler = new GetForwardDocumentLinksCommandHandler(_dbContext, _fakeDataServiceApiClient);
+            _handler = new GetForwardDocumentLinksCommandHandler(_dbContext, _fakeDataServiceApiClient, _fakeLogger);
         }
 
         [TearDown]

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator.UnitTests/GetForwardDocumentLinksCommandHandlerTests.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator.UnitTests/GetForwardDocumentLinksCommandHandlerTests.cs
@@ -85,7 +85,7 @@ namespace SourceDocumentCoordinator.UnitTests
             //Then
             Assert.AreEqual(1, _dbContext.LinkedDocument.Count());
             Assert.AreEqual("RSDRA2019000130872", _dbContext.LinkedDocument.First().RsdraNumber);
-            Assert.AreEqual("Forward", _dbContext.LinkedDocument.First().LinkType);
+            Assert.AreEqual(DocumentLinkType.Forward.ToString(), _dbContext.LinkedDocument.First().LinkType);
         }
 
         [Test]

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator.UnitTests/GetSepDocumentLinksCommandHandlerTests.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator.UnitTests/GetSepDocumentLinksCommandHandlerTests.cs
@@ -86,7 +86,7 @@ namespace SourceDocumentCoordinator.UnitTests
             //Then
             Assert.AreEqual(1, _dbContext.LinkedDocument.Count());
             Assert.AreEqual("RSDRA2019000130872", _dbContext.LinkedDocument.First().RsdraNumber);
-            Assert.AreEqual("SEP", _dbContext.LinkedDocument.First().LinkType);
+            Assert.AreEqual(DocumentLinkType.Sep.ToString(), _dbContext.LinkedDocument.First().LinkType);
         }
 
         [Test]

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator.UnitTests/GetSepDocumentLinksCommandHandlerTests.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator.UnitTests/GetSepDocumentLinksCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Common.Messages.Commands;
 using DataServices.Models;
 using FakeItEasy;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using NServiceBus.Testing;
 using NUnit.Framework;
 using SourceDocumentCoordinator.Handlers;
@@ -16,6 +17,7 @@ namespace SourceDocumentCoordinator.UnitTests
     public class GetSepDocumentLinksCommandHandlerTests
     {
         private IDataServiceApiClient _fakeDataServiceApiClient;
+        private ILogger<GetSepDocumentLinksCommandHandler> _fakeLogger;
         private TestableMessageHandlerContext _handlerContext;
         private GetSepDocumentLinksCommandHandler _handler;
         private WorkflowDbContext _dbContext;
@@ -30,9 +32,10 @@ namespace SourceDocumentCoordinator.UnitTests
             _dbContext = new WorkflowDbContext(dbContextOptions);
 
             _fakeDataServiceApiClient = A.Fake<IDataServiceApiClient>();
+            _fakeLogger = A.Dummy<ILogger<GetSepDocumentLinksCommandHandler>>();
 
             _handlerContext = new TestableMessageHandlerContext();
-            _handler = new GetSepDocumentLinksCommandHandler(_dbContext, _fakeDataServiceApiClient);
+            _handler = new GetSepDocumentLinksCommandHandler(_dbContext, _fakeDataServiceApiClient, _fakeLogger);
         }
 
         [TearDown]

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Handlers/GetBackwardDocumentLinksCommandHandler.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Handlers/GetBackwardDocumentLinksCommandHandler.cs
@@ -1,8 +1,14 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
+using Common.Helpers;
 using Common.Messages.Commands;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using NServiceBus;
+using Serilog.Context;
 using SourceDocumentCoordinator.HttpClients;
 using WorkflowDatabase.EF;
 using WorkflowDatabase.EF.Models;
@@ -12,43 +18,116 @@ namespace SourceDocumentCoordinator.Handlers
     public class GetBackwardDocumentLinksCommandHandler : IHandleMessages<GetBackwardDocumentLinksCommand>
     {
         private readonly IDataServiceApiClient _dataServiceApiClient;
+        private readonly ILogger<GetBackwardDocumentLinksCommandHandler> _logger;
         private readonly WorkflowDbContext _dbContext;
 
-        public GetBackwardDocumentLinksCommandHandler(WorkflowDbContext dbContext, IDataServiceApiClient dataServiceApiClient)
+        public GetBackwardDocumentLinksCommandHandler(
+                                                        WorkflowDbContext dbContext,
+                                                        IDataServiceApiClient dataServiceApiClient,
+                                                        ILogger<GetBackwardDocumentLinksCommandHandler> logger)
         {
             _dataServiceApiClient = dataServiceApiClient;
+            _logger = logger;
             _dbContext = dbContext;
         }
 
         public async Task Handle(GetBackwardDocumentLinksCommand message, IMessageHandlerContext context)
         {
+            LogContext.PushProperty("MessageId", context.MessageId);
+            LogContext.PushProperty("Message", message.ToJSONSerializedString());
+            LogContext.PushProperty("EventName", nameof(GetBackwardDocumentLinksCommand));
+            LogContext.PushProperty("MessageCorrelationId", message.CorrelationId);
+            LogContext.PushProperty("ProcessId", message.ProcessId);
+            LogContext.PushProperty("SourceDocumentId", message.SourceDocumentId);
+
+            _logger.LogInformation("Entering {EventName} handler with: {Message}");
+
             var docLinks = await _dataServiceApiClient.GetBackwardDocumentLinks(message.SourceDocumentId);
+
+            if (docLinks == null || docLinks.Count == 0)
+            {
+                _logger.LogInformation("No Backward linked documents found for SourceDocumentId: {SourceDocumentId}");
+
+                return;
+            }
+
             var linkedDocIds = docLinks.Select(s => s.DocId1).ToList(); //Backward Linked will have DocId2 as sdocId, while DocId1 as LinkedSdocId
 
-            if (linkedDocIds?.Count == 0) return;
+            LogContext.PushProperty("LinkedDocuments", linkedDocIds.ToJSONSerializedString());
 
+            _logger.LogInformation("Backward linked documents found for SourceDocumentId: {SourceDocumentId}; LinkedDocuments: {LinkedDocuments}");
+
+            var failedLinkedDocuments = new StringBuilder(linkedDocIds.Count);
+
+            await PersistLinkedDocuments(message, linkedDocIds, failedLinkedDocuments);
+
+            if (failedLinkedDocuments.Length > 0)
+            {
+                throw new ApplicationException(
+                    $"Errors while adding Backward linked documents to SourceDocumentId: {message.SourceDocumentId}:" +
+                            $"{Environment.NewLine}{failedLinkedDocuments}");
+            }
+
+            _logger.LogInformation("Successfully Completed Event {EventName}: {Message}");
+
+        }
+
+        private async Task PersistLinkedDocuments(GetBackwardDocumentLinksCommand message, IEnumerable<int> linkedDocIds,
+            StringBuilder failedLinkedDocuments)
+        {
             foreach (var linkedDocId in linkedDocIds)
             {
-                var documentAssessmentData = await _dataServiceApiClient.GetAssessmentData(linkedDocId);
+                LogContext.PushProperty("LinkedDocument", linkedDocId);
 
-                var linkedDocument = new LinkedDocument
+                _logger.LogInformation(
+                    "Adding Backward LinkedDocument: {LinkedDocument} to SourceDocumentId: {SourceDocumentId}");
+
+                try
                 {
-                    ProcessId = message.ProcessId,
-                    PrimarySdocId = message.SourceDocumentId,
-                    LinkedSdocId = documentAssessmentData.SdocId,
-                    RsdraNumber = documentAssessmentData.SourceName,
-                    SourceDocumentName = documentAssessmentData.Name,
-                    ReceiptDate = documentAssessmentData.ReceiptDate,
-                    SourceDocumentType = documentAssessmentData.DocumentType,
-                    SourceNature = documentAssessmentData.SourceName,
-                    Datum = documentAssessmentData.Datum,
-                    LinkType = "Backward",
-                    Status = LinkedDocumentRetrievalStatus.NotAttached.ToString(),
-                    Created = DateTime.Now
-                };
+                    var documentAssessmentData = await _dataServiceApiClient.GetAssessmentData(linkedDocId);
 
-                _dbContext.Add(linkedDocument);
-                _dbContext.SaveChanges();
+                    var linkedDocument = await _dbContext.LinkedDocument.FirstOrDefaultAsync(l =>
+                        l.ProcessId == message.ProcessId
+                        && l.LinkedSdocId == documentAssessmentData.SdocId
+                        && l.LinkType == DocumentLinkType.Backward.ToString());
+
+                    var isNew = linkedDocument == null;
+
+                    if (isNew)
+                    {
+                        linkedDocument = new LinkedDocument();
+                    }
+
+                    linkedDocument.ProcessId = message.ProcessId;
+                    linkedDocument.PrimarySdocId = message.SourceDocumentId;
+                    linkedDocument.LinkedSdocId = documentAssessmentData.SdocId;
+                    linkedDocument.RsdraNumber = documentAssessmentData.SourceName;
+                    linkedDocument.SourceDocumentName = documentAssessmentData.Name;
+                    linkedDocument.ReceiptDate = documentAssessmentData.ReceiptDate;
+                    linkedDocument.SourceDocumentType = documentAssessmentData.DocumentType;
+                    linkedDocument.SourceNature = documentAssessmentData.SourceName;
+                    linkedDocument.Datum = documentAssessmentData.Datum;
+                    linkedDocument.LinkType = DocumentLinkType.Backward.ToString();
+                    linkedDocument.Status = LinkedDocumentRetrievalStatus.NotAttached.ToString();
+                    linkedDocument.Created = DateTime.Now;
+
+                    if (isNew)
+                    {
+                        await _dbContext.LinkedDocument.AddAsync(linkedDocument);
+                    }
+
+                    await _dbContext.SaveChangesAsync();
+
+                    _logger.LogInformation(
+                        "Successfully added Backward LinkedDocument: {LinkedDocument} to SourceDocumentId: {SourceDocumentId}");
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "Failed to add Backward LinkedDocument: {LinkedDocument} to SourceDocumentId: {SourceDocumentId}");
+
+                    failedLinkedDocuments.AppendLine(
+                        $"Failed to add Backward LinkedDocument: {linkedDocId} to SourceDocumentId: {message.SourceDocumentId}: {e.Message}");
+                }
             }
         }
     }

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Handlers/GetForwardDocumentLinksCommandHandler.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Handlers/GetForwardDocumentLinksCommandHandler.cs
@@ -1,8 +1,14 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
+using Common.Helpers;
 using Common.Messages.Commands;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using NServiceBus;
+using Serilog.Context;
 using SourceDocumentCoordinator.HttpClients;
 using WorkflowDatabase.EF;
 using WorkflowDatabase.EF.Models;
@@ -13,42 +19,116 @@ namespace SourceDocumentCoordinator.Handlers
     {
         private readonly WorkflowDbContext _dbContext;
         private readonly IDataServiceApiClient _dataServiceApiClient;
+        private readonly ILogger<GetForwardDocumentLinksCommandHandler> _logger;
 
-        public GetForwardDocumentLinksCommandHandler(WorkflowDbContext dbContext, IDataServiceApiClient dataServiceApiClient)
+        public GetForwardDocumentLinksCommandHandler(
+            WorkflowDbContext dbContext,
+            IDataServiceApiClient dataServiceApiClient,
+            ILogger<GetForwardDocumentLinksCommandHandler> logger)
         {
             _dbContext = dbContext;
             _dataServiceApiClient = dataServiceApiClient;
+            _logger = logger;
         }
+
         public async Task Handle(GetForwardDocumentLinksCommand message, IMessageHandlerContext context)
         {
+            LogContext.PushProperty("MessageId", context.MessageId);
+            LogContext.PushProperty("Message", message.ToJSONSerializedString());
+            LogContext.PushProperty("EventName", nameof(GetForwardDocumentLinksCommand));
+            LogContext.PushProperty("MessageCorrelationId", message.CorrelationId);
+            LogContext.PushProperty("ProcessId", message.ProcessId);
+            LogContext.PushProperty("SourceDocumentId", message.SourceDocumentId);
+
+            _logger.LogInformation("Entering {EventName} handler with: {Message}");
+
             var docLinks = await _dataServiceApiClient.GetForwardDocumentLinks(message.SourceDocumentId);
+
+            if (docLinks == null || docLinks.Count == 0)
+            {
+                _logger.LogInformation("No Forward linked documents found for SourceDocumentId: {SourceDocumentId}");
+
+                return;
+            }
+
             var linkedDocIds = docLinks.Select(s => s.DocId2).ToList();
 
-            if (linkedDocIds?.Count == 0) return;
+            LogContext.PushProperty("LinkedDocuments", linkedDocIds.ToJSONSerializedString());
 
+            _logger.LogInformation("Forward linked documents found for SourceDocumentId: {SourceDocumentId}; LinkedDocuments: {LinkedDocuments}");
+
+            var failedLinkedDocuments = new StringBuilder(linkedDocIds.Count);
+
+            await PersistLinkedDocuments(message, linkedDocIds, failedLinkedDocuments);
+
+            if (failedLinkedDocuments.Length > 0)
+            {
+                throw new ApplicationException(
+                    $"Errors while adding Backward linked documents to SourceDocumentId: {message.SourceDocumentId}:" +
+                    $"{Environment.NewLine}{failedLinkedDocuments}");
+            }
+
+            _logger.LogInformation("Successfully Completed Event {EventName}: {Message}");
+        }
+
+        private async Task PersistLinkedDocuments(GetForwardDocumentLinksCommand message, IEnumerable<int> linkedDocIds,
+            StringBuilder failedLinkedDocuments)
+        {
             foreach (var linkedDocId in linkedDocIds)
             {
-                var documentAssessmentData = await _dataServiceApiClient.GetAssessmentData(linkedDocId);
+                LogContext.PushProperty("LinkedDocument", linkedDocId);
 
-                var linkedDocument = new LinkedDocument
+                _logger.LogInformation(
+                    "Adding Forward LinkedDocument: {LinkedDocument} to SourceDocumentId: {SourceDocumentId}");
+
+                try
                 {
-                    ProcessId = message.ProcessId,
-                    PrimarySdocId = message.SourceDocumentId,
-                    LinkedSdocId = documentAssessmentData.SdocId,
-                    RsdraNumber = documentAssessmentData.SourceName,
-                    SourceDocumentName = documentAssessmentData.Name,
-                    ReceiptDate = documentAssessmentData.ReceiptDate,
-                    SourceDocumentType = documentAssessmentData.DocumentType,
-                    SourceNature = documentAssessmentData.SourceName,
-                    Datum = documentAssessmentData.Datum,
-                    LinkType = "Forward",
-                    Status = LinkedDocumentRetrievalStatus.NotAttached.ToString(),
-                    Created = DateTime.Now
-                };
+                    var documentAssessmentData = await _dataServiceApiClient.GetAssessmentData(linkedDocId);
 
-                _dbContext.Add(linkedDocument);
-                _dbContext.SaveChanges();
+                    var linkedDocument = await _dbContext.LinkedDocument.FirstOrDefaultAsync(l =>
+                        l.ProcessId == message.ProcessId
+                        && l.LinkedSdocId == documentAssessmentData.SdocId
+                        && l.LinkType == DocumentLinkType.Forward.ToString());
+
+                    var isNew = linkedDocument == null;
+
+                    if (isNew)
+                    {
+                        linkedDocument = new LinkedDocument();
+                    }
+
+                    linkedDocument.ProcessId = message.ProcessId;
+                    linkedDocument.PrimarySdocId = message.SourceDocumentId;
+                    linkedDocument.LinkedSdocId = documentAssessmentData.SdocId;
+                    linkedDocument.RsdraNumber = documentAssessmentData.SourceName;
+                    linkedDocument.SourceDocumentName = documentAssessmentData.Name;
+                    linkedDocument.ReceiptDate = documentAssessmentData.ReceiptDate;
+                    linkedDocument.SourceDocumentType = documentAssessmentData.DocumentType;
+                    linkedDocument.SourceNature = documentAssessmentData.SourceName;
+                    linkedDocument.Datum = documentAssessmentData.Datum;
+                    linkedDocument.LinkType = DocumentLinkType.Forward.ToString();
+                    linkedDocument.Status = LinkedDocumentRetrievalStatus.NotAttached.ToString();
+                    linkedDocument.Created = DateTime.Now;
+
+                    if (isNew)
+                    {
+                        await _dbContext.LinkedDocument.AddAsync(linkedDocument);
+                    }
+
+                    await _dbContext.SaveChangesAsync();
+
+                    _logger.LogInformation(
+                        "Successfully added Forward LinkedDocument: {LinkedDocument} to SourceDocumentId: {SourceDocumentId}");
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "Failed to add Forward LinkedDocument: {LinkedDocument} to SourceDocumentId: {SourceDocumentId}");
+
+                    failedLinkedDocuments.AppendLine(
+                        $"Failed to add Forward LinkedDocument: {linkedDocId} to SourceDocumentId: {message.SourceDocumentId}: {e.Message}");
+                }
             }
         }
     }
+
 }

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Handlers/GetSepDocumentLinksCommandHandler.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Handlers/GetSepDocumentLinksCommandHandler.cs
@@ -1,7 +1,14 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
+using Common.Helpers;
 using Common.Messages.Commands;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using NServiceBus;
+using Serilog.Context;
 using SourceDocumentCoordinator.HttpClients;
 using WorkflowDatabase.EF;
 using WorkflowDatabase.EF.Models;
@@ -11,41 +18,115 @@ namespace SourceDocumentCoordinator.Handlers
     public class GetSepDocumentLinksCommandHandler : IHandleMessages<GetSepDocumentLinksCommand>
     {
         private readonly IDataServiceApiClient _dataServiceApiClient;
+        private readonly ILogger<GetSepDocumentLinksCommandHandler> _logger;
         private readonly WorkflowDbContext _dbContext;
 
-        public GetSepDocumentLinksCommandHandler(WorkflowDbContext dbContext, IDataServiceApiClient dataServiceApiClient)
+        public GetSepDocumentLinksCommandHandler(
+            WorkflowDbContext dbContext,
+            IDataServiceApiClient dataServiceApiClient,
+            ILogger<GetSepDocumentLinksCommandHandler> logger)
         {
             _dataServiceApiClient = dataServiceApiClient;
+            _logger = logger;
             _dbContext = dbContext;
         }
+
         public async Task Handle(GetSepDocumentLinksCommand message, IMessageHandlerContext context)
         {
+            LogContext.PushProperty("MessageId", context.MessageId);
+            LogContext.PushProperty("Message", message.ToJSONSerializedString());
+            LogContext.PushProperty("EventName", nameof(GetSepDocumentLinksCommand));
+            LogContext.PushProperty("MessageCorrelationId", message.CorrelationId);
+            LogContext.PushProperty("ProcessId", message.ProcessId);
+            LogContext.PushProperty("SourceDocumentId", message.SourceDocumentId);
+
+            _logger.LogInformation("Entering {EventName} handler with: {Message}");
+
             var docLinks = await _dataServiceApiClient.GetSepDocumentLinks(message.SourceDocumentId);
 
-            if (docLinks?.Count == 0) return;
-
-            foreach (var documentObject in docLinks)
+            if (docLinks == null || docLinks.Count == 0)
             {
-                var documentAssessmentData = await _dataServiceApiClient.GetAssessmentData(documentObject.Id);
+                _logger.LogInformation("No SEP linked documents found for SourceDocumentId: {SourceDocumentId}");
 
-                var linkedDocument = new LinkedDocument
+                return;
+            }
+
+            var linkedDocIds = docLinks.Select(s => s.Id).ToList();
+
+            LogContext.PushProperty("LinkedDocuments", linkedDocIds.ToJSONSerializedString());
+
+            _logger.LogInformation("SEP linked documents found for SourceDocumentId: {SourceDocumentId}; LinkedDocuments: {LinkedDocuments}");
+
+            var failedLinkedDocuments = new StringBuilder(linkedDocIds.Count);
+
+            await PersistLinkedDocuments(message, linkedDocIds, failedLinkedDocuments);
+
+            if (failedLinkedDocuments.Length > 0)
+            {
+                throw new ApplicationException(
+                    $"Errors while adding Backward linked documents to SourceDocumentId: {message.SourceDocumentId}:" +
+                    $"{Environment.NewLine}{failedLinkedDocuments}");
+            }
+
+            _logger.LogInformation("Successfully Completed Event {EventName}: {Message}");
+        }
+
+        private async Task PersistLinkedDocuments(GetSepDocumentLinksCommand message, IEnumerable<int> linkedDocIds,
+            StringBuilder failedLinkedDocuments)
+        {
+            foreach (var linkedDocId in linkedDocIds)
+            {
+                LogContext.PushProperty("LinkedDocument", linkedDocId);
+
+                _logger.LogInformation(
+                    "Adding SEP LinkedDocument: {LinkedDocument} to SourceDocumentId: {SourceDocumentId}");
+
+                try
                 {
-                    ProcessId = message.ProcessId,
-                    PrimarySdocId = message.SourceDocumentId,
-                    LinkedSdocId = documentAssessmentData.SdocId,
-                    RsdraNumber = documentAssessmentData.SourceName,
-                    SourceDocumentName = documentAssessmentData.Name,
-                    ReceiptDate = documentAssessmentData.ReceiptDate,
-                    SourceDocumentType = documentAssessmentData.DocumentType,
-                    SourceNature = documentAssessmentData.SourceName,
-                    Datum = documentAssessmentData.Datum,
-                    LinkType = "SEP",
-                    Status = LinkedDocumentRetrievalStatus.NotAttached.ToString(),
-                    Created = DateTime.Now
-                };
+                    var documentAssessmentData = await _dataServiceApiClient.GetAssessmentData(linkedDocId);
 
-                _dbContext.Add(linkedDocument);
-                _dbContext.SaveChanges();
+                    var linkedDocument = await _dbContext.LinkedDocument.FirstOrDefaultAsync(l =>
+                        l.ProcessId == message.ProcessId
+                        && l.LinkedSdocId == documentAssessmentData.SdocId
+                        && l.LinkType == DocumentLinkType.Sep.ToString());
+
+                    var isNew = linkedDocument == null;
+
+                    if (isNew)
+                    {
+                        linkedDocument = new LinkedDocument();
+                    }
+
+                    linkedDocument.ProcessId = message.ProcessId;
+                    linkedDocument.PrimarySdocId = message.SourceDocumentId;
+                    linkedDocument.LinkedSdocId = documentAssessmentData.SdocId;
+                    linkedDocument.RsdraNumber = documentAssessmentData.SourceName;
+                    linkedDocument.SourceDocumentName = documentAssessmentData.Name;
+                    linkedDocument.ReceiptDate = documentAssessmentData.ReceiptDate;
+                    linkedDocument.SourceDocumentType = documentAssessmentData.DocumentType;
+                    linkedDocument.SourceNature = documentAssessmentData.SourceName;
+                    linkedDocument.Datum = documentAssessmentData.Datum;
+                    linkedDocument.LinkType = DocumentLinkType.Sep.ToString();
+                    linkedDocument.Status = LinkedDocumentRetrievalStatus.NotAttached.ToString();
+                    linkedDocument.Created = DateTime.Now;
+
+                    if (isNew)
+                    {
+                        await _dbContext.LinkedDocument.AddAsync(linkedDocument);
+                    }
+
+                    await _dbContext.SaveChangesAsync();
+
+                    _logger.LogInformation(
+                        "Successfully added SEP LinkedDocument: {LinkedDocument} to SourceDocumentId: {SourceDocumentId}");
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "Failed to add SEP LinkedDocument: {LinkedDocument} to SourceDocumentId: {SourceDocumentId}");
+
+                    failedLinkedDocuments.AppendLine(
+                        $"Failed to add SEP LinkedDocument: {linkedDocId} to SourceDocumentId: {message.SourceDocumentId}: {e.Message}");
+                }
             }
         }
     }

--- a/src/WorkflowCoordinator/WorkflowCoordinator.UnitTests/AssessmentPollingSagaTests.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator.UnitTests/AssessmentPollingSagaTests.cs
@@ -195,7 +195,7 @@ namespace WorkflowCoordinator.UnitTests
             await _saga.Timeout(new ExecuteAssessmentPollingTask(), _handlerContext).ConfigureAwait(false);
 
             //Then
-            Assert.AreEqual(1, _handlerContext.SentMessages.Length);
+            Assert.GreaterOrEqual(_handlerContext.SentMessages.Length, 1);
             var executeAssessmentPollingTask = _handlerContext.SentMessages.SingleOrDefault(t =>
                 t.Message is ExecuteAssessmentPollingTask);
             Assert.IsNotNull(executeAssessmentPollingTask, $"No timeout of type {nameof(ExecuteAssessmentPollingTask)} seen.");

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Sagas/AssessmentPollingSaga.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Sagas/AssessmentPollingSaga.cs
@@ -93,7 +93,7 @@ namespace WorkflowCoordinator.Sagas
             foreach (var assessment in assessments)
             {
                 var isExists = await
-                    _dbContext.AssessmentData.AnyAsync(a => a.PrimarySdocId == assessment.Id);
+                    _dbContext.WorkflowInstance.AnyAsync(a => a.PrimarySdocId == assessment.Id);
 
                 if (!isExists) return assessment;
             }


### PR DESCRIPTION
### SourceDocumentCoordinator

- Get*DocumentLinksCommandHandler.cs: Improved resiliency, added logging

### WorkflowCoordinator

- AssessmentPollingSaga.cs: Use WorkflowInstance table, instead of AssessmentData table, to decide whether an assessment exists in our system

### DataServices

- DataAccessApi.cs: Added friendly message when no assessment data returned

### WorkflowDatabase.EF

- Added DocumentLinkType enum

### Portal.TestAutomation.Framework

- TestData.cs Temporary fix for AdUser EF change (@benbhall )

### Unit Tests

- Fixed unit tests