### PR TITLE
Features/ad refresh ncneportal

### DIFF
--- a/src/NCNEPortal/Auth/INcneUserDbService.cs
+++ b/src/NCNEPortal/Auth/INcneUserDbService.cs
@@ -7,11 +7,8 @@ namespace NCNEPortal.Auth
 {
     public interface INcneUserDbService
     {
-
         Task<IEnumerable<AdUser>> GetUsersFromDbAsync();
 
         Task<bool> ValidateUserAsync(string username);
-
-        Task UpdateDbFromAdAsync(IEnumerable<Guid> adGroupGuids);
     }
 }

--- a/src/NCNEPortal/Auth/NcneUserDbService.cs
+++ b/src/NCNEPortal/Auth/NcneUserDbService.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Common.Helpers.Auth;
 using Microsoft.EntityFrameworkCore;
@@ -18,39 +17,6 @@ namespace NCNEPortal.Auth
         {
             _ncneWorkflowDbContext = ncneWorkflowDbContext;
             _adDirectoryService = adDirectoryService;
-        }
-
-        /// <summary>
-        /// Update users in database from AD
-        /// </summary>
-        /// <remarks>Bust be awaited from an async function or run with .RunSynchronously()</remarks>
-        public async Task UpdateDbFromAdAsync(IEnumerable<Guid> adGroupGuids)
-        {
-
-            var adGroupMembers = _adDirectoryService.GetGroupMembersFromAdAsync(adGroupGuids).Result;
-            var currentAdUsers = _ncneWorkflowDbContext.AdUser.ToList();
-
-            var newAdUsers = adGroupMembers.Where(m =>
-                currentAdUsers.All(c => c.UserPrincipalName != m.UserPrincipalName)).Select(n => new AdUser
-                {
-                    DisplayName = n.DisplayName,
-                    UserPrincipalName = n.UserPrincipalName,
-
-                    // This will eventually hook into checks
-                    // For now, it just records the date user was first stored in our database
-                    LastCheckedDate = DateTime.UtcNow
-                });
-
-            _ncneWorkflowDbContext.AdUser.AddRange(newAdUsers);
-
-            try
-            {
-                await _ncneWorkflowDbContext.SaveChangesAsync();
-            }
-            catch (Exception e)
-            {
-                throw new ApplicationException("Error saving AD users to database.", e);
-            }
         }
 
         /// <summary>

--- a/src/NCNEPortal/Configuration/AdUserUpdateServiceConfig.cs
+++ b/src/NCNEPortal/Configuration/AdUserUpdateServiceConfig.cs
@@ -1,0 +1,8 @@
+﻿namespace NCNEPortal.Configuration
+{
+    public class AdUserUpdateServiceConfig
+    {
+        public int AdUpdateIntervalSeconds { get; set; }
+
+    }
+}

--- a/src/NCNEPortal/Configuration/AdUserUpdateServiceSecrets.cs
+++ b/src/NCNEPortal/Configuration/AdUserUpdateServiceSecrets.cs
@@ -1,0 +1,9 @@
+﻿namespace NCNEPortal.Configuration
+{
+    public class AdUserUpdateServiceSecrets
+    {
+
+        // Expected to come from KV as comma separated string of GUIDs
+        public string AdUserGroups { get; set; }
+    }
+}

--- a/src/NCNEPortal/Configuration/StartupSecretsConfig.cs
+++ b/src/NCNEPortal/Configuration/StartupSecretsConfig.cs
@@ -8,8 +8,5 @@
         public string SqlLoggingUsername { get; set; }
         public string SqlLoggingPassword { get; set; }
         public string ClientAzureAdSecret { get; set; }
-
-        // Expected to come from KV as comma separated
-        public string AdUserGroups { get; set; }
     }
 }

--- a/src/NCNEPortal/HostedServices/AdUserUpdateService.cs
+++ b/src/NCNEPortal/HostedServices/AdUserUpdateService.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Common.Helpers.Auth;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NCNEPortal.Configuration;
+using NCNEWorkflowDatabase.EF;
+using NCNEWorkflowDatabase.EF.Models;
+using Serilog.Context;
+
+
+namespace NCNEPortal.HostedServices
+{
+    public class AdUserUpdateService : BackgroundService
+    {
+        private readonly ILogger<AdUserUpdateService> _logger;
+        private readonly IAdDirectoryService _adDirectoryService;
+        private readonly AdUserUpdateServiceSecrets _secrets;
+        private readonly TimeSpan _updateIntervalSeconds;
+
+        // Hosted service is singleton so we need to safely consume our scoped services
+        private readonly IServiceScopeFactory _serviceScopeFactory;
+
+        public AdUserUpdateService(ILogger<AdUserUpdateService> logger,
+            IOptions<AdUserUpdateServiceConfig> config,
+            IOptions<AdUserUpdateServiceSecrets> secrets,
+            IAdDirectoryService adDirectoryService,
+            IServiceScopeFactory serviceScopeFactory)
+        {
+            _logger = logger;
+            _adDirectoryService = adDirectoryService;
+            _secrets = secrets.Value;
+            _serviceScopeFactory = serviceScopeFactory;
+
+            _updateIntervalSeconds = TimeSpan.FromSeconds(config.Value.AdUpdateIntervalSeconds > 0
+                ? config.Value.AdUpdateIntervalSeconds
+                : 3600);
+
+            LogContext.PushProperty("AdUserUpdateService", nameof(AdUserUpdateService));
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            _logger.LogInformation($"{nameof(AdUserUpdateService)}: Starting.");
+
+            stoppingToken.Register(() =>
+                _logger.LogInformation($"{nameof(AdUserUpdateService)}: Stopping (received cancellation token)."));
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogDebug($"{nameof(AdUserUpdateService)}: Updating users in database from AD.");
+
+                try
+                {
+                    await UpdateDbFromAdAsync();
+                    _logger.LogInformation($"{nameof(AdUserUpdateService)}: Users successfully updated in database from AD.");
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, $"{nameof(AdUserUpdateService)}: Failed to update users from AD.");
+                }
+
+                await Task.Delay(_updateIntervalSeconds, stoppingToken);
+            }
+
+            _logger.LogInformation($"{nameof(AdUserUpdateService)}: Stopping.");
+        }
+
+        private async Task UpdateDbFromAdAsync()
+        {
+            var adGroupMembers =
+                await _adDirectoryService.GetGroupMembersFromAdAsync(ExtractGiudsFromStr(_secrets.AdUserGroups));
+
+            using var scope = _serviceScopeFactory.CreateScope();
+            var workflowDbContext = scope.ServiceProvider.GetRequiredService<NcneWorkflowDbContext>();
+
+            var currentAdUsers = await workflowDbContext.AdUser.ToListAsync();
+
+            var newAdUsers = adGroupMembers.Where(m =>
+                currentAdUsers.All(c => c.UserPrincipalName != m.UserPrincipalName)).Select(n => new AdUser
+                {
+                    DisplayName = n.DisplayName,
+                    UserPrincipalName = n.UserPrincipalName,
+                    // TODO hook into checks
+                    LastCheckedDate = DateTime.UtcNow
+                }).ToList(); // avoid multiple iterations for counting with ToList()
+
+            if (newAdUsers.Count > 0) _logger.LogInformation($"{nameof(AdUserUpdateService)}: {newAdUsers.Count} new users added to database from AD.");
+
+            workflowDbContext.AdUser.AddRange(newAdUsers);
+
+            await workflowDbContext.SaveChangesAsync();
+        }
+
+        private IEnumerable<Guid> ExtractGiudsFromStr(string adUserGroups)
+        {
+            var guidCollection = adUserGroups.Split(',')
+                    .Where(x => Guid.TryParse(x, out _))
+                    .Select(Guid.Parse).ToList();
+
+            var diff = guidCollection.Count - _secrets.AdUserGroups.Length;
+            if (diff > 0) _logger.LogWarning($"{nameof(AdUserUpdateService)}: {diff} invalid GUIDs supplied in configuration.");
+
+            return guidCollection;
+        }
+    }
+}

--- a/src/NCNEPortal/HostedServices/AdUserUpdateService.cs
+++ b/src/NCNEPortal/HostedServices/AdUserUpdateService.cs
@@ -75,7 +75,7 @@ namespace NCNEPortal.HostedServices
         private async Task UpdateDbFromAdAsync()
         {
             var adGroupMembers =
-                await _adDirectoryService.GetGroupMembersFromAdAsync(ExtractGiudsFromStr(_secrets.AdUserGroups));
+                await _adDirectoryService.GetGroupMembersFromAdAsync(ExtractGuidsFromStr(_secrets.AdUserGroups));
 
             using var scope = _serviceScopeFactory.CreateScope();
             var workflowDbContext = scope.ServiceProvider.GetRequiredService<NcneWorkflowDbContext>();
@@ -98,7 +98,7 @@ namespace NCNEPortal.HostedServices
             await workflowDbContext.SaveChangesAsync();
         }
 
-        private IEnumerable<Guid> ExtractGiudsFromStr(string adUserGroups)
+        private IEnumerable<Guid> ExtractGuidsFromStr(string adUserGroups)
         {
             var guidCollection = adUserGroups.Split(',')
                     .Where(x => Guid.TryParse(x, out _))

--- a/src/NCNEPortal/HostedServices/DatabaseSeedingService.cs
+++ b/src/NCNEPortal/HostedServices/DatabaseSeedingService.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Common.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NCNEWorkflowDatabase.EF;
+
+namespace NCNEPortal.HostedServices
+{
+    public class DatabaseSeedingService : IHostedService
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public DatabaseSeedingService(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var workflowDbContext = scope.ServiceProvider.GetRequiredService<NcneWorkflowDbContext>();
+
+            NcneTestWorkflowDatabaseSeeder.UsingDbContext(workflowDbContext).PopulateTables().SaveChanges();
+
+            return Task.CompletedTask;
+        }
+
+        // Not required
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/src/NCNEPortal/Startup.cs
+++ b/src/NCNEPortal/Startup.cs
@@ -102,7 +102,12 @@ namespace NCNEPortal
             services.AddScoped<IWorkflowStageHelper, WorkflowStageHelper>();
             services.AddScoped<INcneUserDbService, NcneUserDbService>();
 
+
+            // Order of these two is important
+            if (ConfigHelpers.IsLocalDevelopment || ConfigHelpers.IsAzureUat)
+                services.AddHostedService<DatabaseSeedingService>();
             services.AddHostedService<AdUserUpdateService>();
+
 
             services.AddAuthentication(AzureADDefaults.AuthenticationScheme)
                 .AddAzureAD(options =>
@@ -193,8 +198,8 @@ namespace NCNEPortal
 
             // Seeding
 
-            if (ConfigHelpers.IsLocalDevelopment || ConfigHelpers.IsAzureUat)
-                SeedWorkflowDatabase(ncneWorkflowDbContext);
+            //if (ConfigHelpers.IsLocalDevelopment || ConfigHelpers.IsAzureUat)
+            //    SeedWorkflowDatabase(ncneWorkflowDbContext);
         }
 
         private static void SeedWorkflowDatabase(NcneWorkflowDbContext ncneWorkflowDbContext)

--- a/src/NCNEPortal/Startup.cs
+++ b/src/NCNEPortal/Startup.cs
@@ -195,17 +195,6 @@ namespace NCNEPortal
             });
 
             app.UseAzureAppConfiguration();
-
-            // Seeding
-
-            //if (ConfigHelpers.IsLocalDevelopment || ConfigHelpers.IsAzureUat)
-            //    SeedWorkflowDatabase(ncneWorkflowDbContext);
-        }
-
-        private static void SeedWorkflowDatabase(NcneWorkflowDbContext ncneWorkflowDbContext)
-        {
-            NcneTestWorkflowDatabaseSeeder.UsingDbContext(ncneWorkflowDbContext).PopulateTables().SaveChanges();
-            Log.Logger.Information($"NCNEWorkflowDatabase successfully re-seeded.");
         }
     }
 }

--- a/src/Portal/Portal/HostedServices/AdUserUpdateService.cs
+++ b/src/Portal/Portal/HostedServices/AdUserUpdateService.cs
@@ -74,7 +74,7 @@ namespace Portal.HostedServices
         private async Task UpdateDbFromAdAsync()
         {
             var adGroupMembers =
-                await _adDirectoryService.GetGroupMembersFromAdAsync(ExtractGiudsFromStr(_secrets.AdUserGroups));
+                await _adDirectoryService.GetGroupMembersFromAdAsync(ExtractGuidsFromStr(_secrets.AdUserGroups));
 
             using var scope = _serviceScopeFactory.CreateScope();
             var workflowDbContext = scope.ServiceProvider.GetRequiredService<WorkflowDbContext>();
@@ -97,7 +97,7 @@ namespace Portal.HostedServices
             await workflowDbContext.SaveChangesAsync();
         }
 
-        private IEnumerable<Guid> ExtractGiudsFromStr(string adUserGroups)
+        private IEnumerable<Guid> ExtractGuidsFromStr(string adUserGroups)
         {
             var guidCollection = adUserGroups.Split(',')
                     .Where(x => Guid.TryParse(x, out _))


### PR DESCRIPTION
As per PR we did debrief for yesterday with Db Assessment Portal - new background service for updating our AD users periodically.

Have also moved call to seeding into a hosted service to fix a race between cleaning the AdUser table in development+UAT and updating it from AD. It is worth considering tidying up the seeding classes themselves into a utils project at some point but left for now.