### PR TITLE
NCNE : system comments for 3PS changes

### DIFF
--- a/src/NCNEPortal.UnitTests/CommentsHelperTests.cs
+++ b/src/NCNEPortal.UnitTests/CommentsHelperTests.cs
@@ -95,7 +95,8 @@ namespace NCNEPortal.UnitTests
         [TestCase(NcneCommentType.V2Change, "Valid User3", "V2 role changed to ")]
         [TestCase(NcneCommentType.PublisherChange, "Valid User4", "Publisher role changed to ")]
         [TestCase(NcneCommentType.DateChange, "", "Task Information dates changed")]
-        public async Task Adding_System_Comments_for_Date_or_Role_change_adds_New_Comment(NcneCommentType changeType, string roleName, string commentText)
+        [TestCase(NcneCommentType.ThreePsChange, "", "3PS Details changed")]
+        public async Task Adding_System_Comments_for_Date_or_Role_or_3PS_change_adds_New_Comment(NcneCommentType changeType, string roleName, string commentText)
         {
             //create a random processId
             var processId = 300 + (int)changeType;

--- a/src/NCNEPortal/Enums/NcneCommentType.cs
+++ b/src/NCNEPortal/Enums/NcneCommentType.cs
@@ -10,7 +10,7 @@
         V2Change,
         PublisherChange,
         CarisPublish,
-        CompleteWorkflow
-
+        CompleteWorkflow,
+        ThreePsChange
     }
 }

--- a/src/NCNEPortal/Helpers/CommentsHelper.cs
+++ b/src/NCNEPortal/Helpers/CommentsHelper.cs
@@ -45,6 +45,7 @@ namespace NCNEPortal.Helpers
                 NcneCommentType.PublisherChange => "Publisher role changed to " + roleName,
                 NcneCommentType.CarisPublish => "Chart published in CARIS",
                 NcneCommentType.CompleteWorkflow => "Workflow completed",
+                NcneCommentType.ThreePsChange => "3PS Details changed",
                 _ => throw new ArgumentOutOfRangeException(nameof(changeType), changeType, null),
             };
 

--- a/src/NCNEPortal/Pages/Workflow.cshtml.cs
+++ b/src/NCNEPortal/Pages/Workflow.cshtml.cs
@@ -655,7 +655,7 @@ namespace NCNEPortal
 
             }
 
-            await AddSystemComments(task, processId, Compiler, Verifier1, Verifier2, Publisher, CurrentUser.DisplayName);
+            await AddSystemComments(task, processId, Compiler, Verifier1, Verifier2, Publisher);
 
             task.RepromatDate = RepromatDate;
 
@@ -685,7 +685,7 @@ namespace NCNEPortal
         }
 
         private async Task AddSystemComments(TaskInfo task, int processId, string compiler,
-              string v1, string v2, string publisher, string us)
+              string v1, string v2, string publisher)
         {
 
 
@@ -710,6 +710,15 @@ namespace NCNEPortal
             if (!string.IsNullOrEmpty(Publisher) && task.TaskRole.Publisher != publisher)
                 await _commentsHelper.AddTaskSystemComment(NcneCommentType.PublisherChange, processId, CurrentUser.DisplayName,
                     null, Publisher, null);
+
+            if ((task.ThreePs != SentTo3Ps) || (task.SentDate3Ps != SendDate3ps)
+                                            || (task.ExpectedDate3Ps != ExpectedReturnDate3ps) ||
+                                            (task.ActualDate3Ps != ActualReturnDate3ps))
+            {
+                await _commentsHelper.AddTaskSystemComment(NcneCommentType.ThreePsChange, processId,
+                    CurrentUser.DisplayName,
+                    null, null, null);
+            }
         }
 
 


### PR DESCRIPTION
1. Added a new comment type ThreePsChange.
2. Whenever there is a change in any of the 3PS fields, a system comment will be added while saving the Task Information.