### PR TITLE
NCNE : Enable publish button only valid chart numbers

### DIFF
--- a/src/NCNEPortal.UnitTests/PageValidationTests.cs
+++ b/src/NCNEPortal.UnitTests/PageValidationTests.cs
@@ -1,5 +1,4 @@
-﻿using Common.Helpers.Auth;
-using FakeItEasy;
+﻿using FakeItEasy;
 using Microsoft.EntityFrameworkCore;
 using NCNEPortal.Auth;
 using NCNEPortal.Enums;
@@ -27,9 +26,6 @@ namespace NCNEPortal.UnitTests
                 .UseInMemoryDatabase(databaseName: "inmemory")
                 .Options;
 
-            new NcneWorkflowDbContext(dbContextOptions);
-
-            A.Fake<IAdDirectoryService>();
             _fakeNcneUserDbService = A.Fake<INcneUserDbService>();
 
             _pageValidationHelper = new PageValidationHelper(_fakeNcneUserDbService);

--- a/src/NCNEPortal.UnitTests/PageValidationTests.cs
+++ b/src/NCNEPortal.UnitTests/PageValidationTests.cs
@@ -15,8 +15,6 @@ namespace NCNEPortal.UnitTests
     [TestFixture]
     public class PageValidationTests
     {
-        private NcneWorkflowDbContext _dbContext;
-        private IAdDirectoryService _fakeAdDirectoryService;
         private INcneUserDbService _fakeNcneUserDbService;
         private PageValidationHelper _pageValidationHelper;
         private List<AdUser> _validUsers;
@@ -29,9 +27,9 @@ namespace NCNEPortal.UnitTests
                 .UseInMemoryDatabase(databaseName: "inmemory")
                 .Options;
 
-            _dbContext = new NcneWorkflowDbContext(dbContextOptions);
+            new NcneWorkflowDbContext(dbContextOptions);
 
-            _fakeAdDirectoryService = A.Fake<IAdDirectoryService>();
+            A.Fake<IAdDirectoryService>();
             _fakeNcneUserDbService = A.Fake<INcneUserDbService>();
 
             _pageValidationHelper = new PageValidationHelper(_fakeNcneUserDbService);

--- a/src/NCNEPortal/Pages/Workflow.cshtml
+++ b/src/NCNEPortal/Pages/Workflow.cshtml
@@ -389,7 +389,7 @@
 
         <div id="CommentsSection" class="card-body p-3">
 
-            <table id="TaskCommentsTable" class="table table-striped m-2" id="generic-comments-table">
+            <table id="TaskCommentsTable" class="table table-striped m-2">
                 <tbody>
                     @if (Model.TaskComments != null)
                     {
@@ -613,7 +613,7 @@
 
             <div class="modal-footer">
                 <button type="button" id="btnPublishCancel" class="btn btn-outline-secondary pl-4 pr-4" accesskey="c" data-dismiss="modal" data-toggle="tooltip" data-placement="left" title="Cancel & close this popup">Cancel</button>
-                <button type="button" form="frmPublish" id="btnPublish" class="btn btn-primary pl-4 pr-4" accesskey="a" data-toggle="tooltip" data-placement="left" title="Continue">Publish</button>
+                <button type="button" form="frmPublish" id="btnPublish" class="btn btn-primary pl-4 pr-4" accesskey="a" data-toggle="tooltip" data-placement="left" disabled title="Publish">Publish</button>
             </div>
         </div>
     </div>

--- a/src/NCNEPortal/wwwroot/js/Workflow.js
+++ b/src/NCNEPortal/wwwroot/js/Workflow.js
@@ -71,6 +71,7 @@
                 $("#chartTitle").html(result[1]);
                 $("#editionNumber").html(result[2]);
                 $("#chartVersion").html(result[3]);
+                $("#btnPublish").prop("disabled", false);
 
             },
             error: function (error) {
@@ -83,6 +84,7 @@
                     $("#publishChartErrorMessage").text(responseJson);
                     $("#publishChartError").collapse("show");
                 }
+                $("#btnPublish").prop("disabled", true);
             }
         });
 
@@ -188,6 +190,7 @@
                     $("#publishChartError").collapse("show");
                 }
                 $("#PublishConfirmModal").modal("hide");
+                $("#btnPublish").prop("disabled", true);
                 $("#PublishChartModal").modal("show");
             }
         });


### PR DESCRIPTION
1. Disable the publish button by default.
2. Enable it when metadata is retrieved from CARIS successfully
3. Disable it for Invalid chart numbers
4. Disable it again when the publish screen shown after publish errors.