### PR TITLE
Fixed CachedHpdWorkspace table being emptied when to seeding DB

### DIFF
--- a/src/Common.Helpers/DatabasesHelpers.cs
+++ b/src/Common.Helpers/DatabasesHelpers.cs
@@ -55,7 +55,6 @@ namespace Common.Helpers
             workflowDbContext.Database.ExecuteSqlCommand("delete from [CarisProjectDetails]");
             workflowDbContext.Database.ExecuteSqlCommand("delete from [WorkflowInstance]");
             workflowDbContext.Database.ExecuteSqlCommand("delete from [HpdUser]");
-            workflowDbContext.Database.ExecuteSqlCommand("delete from [CachedHpdWorkspace]");
         }
 
 


### PR DESCRIPTION
Fixed CachedHpdWorkspace table being emptied prior to seeding Workflow DB when running locally