### PR TITLE
Fix build warning - remove xmlserializer generator.

### DIFF
--- a/src/Portal/Portal/Portal.csproj
+++ b/src/Portal/Portal/Portal.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.3" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.13.0" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.76" />
-    <PackageReference Include="Microsoft.XmlSerializer.Generator" Version="2.2.0" />
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.4.0" />


### PR DESCRIPTION
Fix build warning - remove xmlserializer generator - no requirement in service for startup performance.