### PR TITLE
Db Update : Adding Serilog logging and seeding data

### DIFF
--- a/src/Common.Helpers/DbUpdateWorkflowDatabaseSeeder.cs
+++ b/src/Common.Helpers/DbUpdateWorkflowDatabaseSeeder.cs
@@ -1,0 +1,106 @@
+﻿using DbUpdateWorkflowDatabase.EF;
+using DbUpdateWorkflowDatabase.EF.Models;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Common.Helpers
+{
+    public class DbUpdateWorkflowDatabaseSeeder : ICanPopulateTables, ICanSaveChanges
+    {
+        private readonly DbUpdateWorkflowDbContext _context;
+
+        public DbUpdateWorkflowDatabaseSeeder(DbUpdateWorkflowDbContext context)
+        {
+            _context = context;
+        }
+
+        public static ICanPopulateTables UsingDbContext(DbUpdateWorkflowDbContext context)
+        {
+            return new DbUpdateWorkflowDatabaseSeeder(context);
+
+        }
+
+        public ICanSaveChanges PopulateTables()
+        {
+            DatabasesHelpers.ClearDbUpdateWorkflowDbTables(_context, true);
+
+            AddAdditionalAdUsers();
+
+            PopulateTaskStageType();
+            PopulateChartingArea();
+            PopulateUpdateType();
+            PopulateTaskInfo();
+            PopulateHpdUser();
+
+            return this;
+        }
+
+        private void AddAdditionalAdUsers()
+        {
+            if (!File.Exists(@"Data\Users.json")) throw new FileNotFoundException(@"Data\Users.json");
+
+            var jsonString = File.ReadAllText(@"Data\Users.json");
+            var users = JsonConvert.DeserializeObject<IEnumerable<AdUser>>(jsonString);
+
+            if (users?.Any() ?? false) _context.AdUser.AddRange(users);
+        }
+
+        private void PopulateTaskInfo()
+        {
+            if (!File.Exists(@"Data\TaskInfo.json")) throw new FileNotFoundException(@"Data\TaskInfo.json");
+
+            var jsonString = File.ReadAllText(@"Data\TaskInfo.json");
+            var taskInfo = JsonConvert.DeserializeObject<IEnumerable<TaskInfo>>(jsonString);
+
+            _context.TaskInfo.AddRange(taskInfo);
+        }
+
+        private void PopulateTaskStageType()
+        {
+            if (!File.Exists(@"Data\TaskStageType.json")) throw new FileNotFoundException(@"Data\TaskStageType.json");
+
+            var jsonString = File.ReadAllText(@"Data\TaskStageType.json");
+            var stageType = JsonConvert.DeserializeObject<IEnumerable<TaskStageType>>(jsonString);
+
+            _context.TaskStageType.AddRange(stageType);
+        }
+
+        private void PopulateChartingArea()
+        {
+            if (!File.Exists(@"Data\ChartingAreas.json")) throw new FileNotFoundException(@"Data\ChartingAreas.json");
+
+            var jsonString = File.ReadAllText(@"Data\ChartingAreas.json");
+            var chartType = JsonConvert.DeserializeObject<IEnumerable<ChartingArea>>(jsonString);
+
+            _context.ChartingArea.AddRange(chartType);
+
+        }
+
+        private void PopulateUpdateType()
+        {
+            if (!File.Exists(@"Data\UpdateTypes.json")) throw new FileNotFoundException(@"Data\UpdateTypes.json");
+
+            var jsonString = File.ReadAllText(@"Data\UpdateTypes.json");
+            var workflowType = JsonConvert.DeserializeObject<IEnumerable<UpdateType>>(jsonString);
+
+            _context.UpdateType.AddRange(workflowType);
+        }
+
+        private void PopulateHpdUser()
+        {
+            if (!File.Exists(@"Data\HpdUsers.json")) throw new FileNotFoundException(@"Data\HpdUsers.json");
+
+            var jsonString = File.ReadAllText(@"Data\HpdUsers.json");
+            var hpdUsers = JsonConvert.DeserializeObject<IEnumerable<HpdUser>>(jsonString);
+
+            _context.HpdUser.AddRange(hpdUsers);
+        }
+
+        public void SaveChanges()
+        {
+            _context.SaveChanges();
+        }
+    }
+}

--- a/src/DbUpdatePortal/Auth/DbUpdateUserDbService.cs
+++ b/src/DbUpdatePortal/Auth/DbUpdateUserDbService.cs
@@ -1,0 +1,44 @@
+﻿using Common.Helpers.Auth;
+using DbUpdateWorkflowDatabase.EF;
+using DbUpdateWorkflowDatabase.EF.Models;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace DbUpdatePortal.Auth
+{
+    public class DbUpdateUserDbService : IDbUpdateUserDbService
+    {
+        private readonly DbUpdateWorkflowDbContext _dbUpdateWorkflowDbContext;
+        private readonly IAdDirectoryService _adDirectoryService;
+
+        public DbUpdateUserDbService(DbUpdateWorkflowDbContext dbUpdateWorkflowDbContext, IAdDirectoryService adDirectoryService)
+        {
+            _dbUpdateWorkflowDbContext = dbUpdateWorkflowDbContext;
+            _adDirectoryService = adDirectoryService;
+        }
+
+        /// <summary>
+        /// Get a TM site's users from database
+        /// </summary>
+        /// <returns></returns>
+        public async Task<IEnumerable<AdUser>> GetUsersFromDbAsync()
+        {
+            return await _dbUpdateWorkflowDbContext.AdUser.ToListAsync();
+
+        }
+
+        /// <summary>
+        /// Validate a username exists in the database
+        /// </summary>
+        /// <returns></returns>
+        public async Task<bool> ValidateUserAsync(string username)
+        {
+            // TODO do we ever want to go and check AD then update database if we find a new user
+            // TODO switch to a unique value instead of display name for validating when we switch over
+
+            return await _dbUpdateWorkflowDbContext.AdUser.AnyAsync(u => u.DisplayName.Equals(username, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/src/DbUpdatePortal/Auth/IDbUpdateUserDbService.cs
+++ b/src/DbUpdatePortal/Auth/IDbUpdateUserDbService.cs
@@ -1,0 +1,13 @@
+﻿using DbUpdateWorkflowDatabase.EF.Models;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace DbUpdatePortal.Auth
+{
+    public interface IDbUpdateUserDbService
+    {
+        Task<IEnumerable<AdUser>> GetUsersFromDbAsync();
+
+        Task<bool> ValidateUserAsync(string username);
+    }
+}

--- a/src/DbUpdatePortal/Configuration/AdUserUpdateServiceConfig.cs
+++ b/src/DbUpdatePortal/Configuration/AdUserUpdateServiceConfig.cs
@@ -1,0 +1,8 @@
+﻿namespace DbUpdatePortal.Configuration
+{
+    public class AdUserUpdateServiceConfig
+    {
+        public int AdUpdateIntervalSeconds { get; set; }
+
+    }
+}

--- a/src/DbUpdatePortal/Configuration/AdUserUpdateServiceSecrets.cs
+++ b/src/DbUpdatePortal/Configuration/AdUserUpdateServiceSecrets.cs
@@ -1,0 +1,9 @@
+﻿namespace DbUpdatePortal.Configuration
+{
+    public class AdUserUpdateServiceSecrets
+    {
+
+        // Expected to come from KV as comma separated string of GUIDs
+        public string AdUserGroups { get; set; }
+    }
+}

--- a/src/DbUpdatePortal/Configuration/GeneralConfig.cs
+++ b/src/DbUpdatePortal/Configuration/GeneralConfig.cs
@@ -1,0 +1,13 @@
+namespace DbUpdatePortal.Configuration
+{
+    public class GeneralConfig
+    {
+        public string AzureAdClientId { get; set; }
+        public string TenantId { get; set; }
+        public string CarisNewProjectStatus { get; set; }
+        public string CarisNewProjectPriority { get; set; }
+        public string CarisDbUpdateProjectType { get; set; }
+        public int CarisProjectTimeoutSeconds { get; set; }
+        public int HistoricalTasksInitialNumberOfRecords { get; set; }
+    }
+}

--- a/src/DbUpdatePortal/Configuration/StartupConfig.cs
+++ b/src/DbUpdatePortal/Configuration/StartupConfig.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace DbUpdatePortal.Configuration
+{
+    public class StartupConfig
+    {
+        public string DbUpdateWorkflowDbName { get; set; }
+        public string WorkflowDbServer { get; set; }
+        public string LocalDbServer { get; set; }
+        public Uri AzureDbTokenUrl { get; set; }
+        public string TenantId { get; set; }
+        public string AzureAdClientId { get; set; }
+    }
+}

--- a/src/DbUpdatePortal/Configuration/StartupLoggingConfig.cs
+++ b/src/DbUpdatePortal/Configuration/StartupLoggingConfig.cs
@@ -1,0 +1,11 @@
+﻿namespace DbUpdatePortal.Configuration
+{
+    public class StartupLoggingConfig
+    {
+        public string WorkflowDbName { get; set; }
+        public string WorkflowDbServer { get; set; }
+        public string LocalDbServer { get; set; }
+        public string LocalDbName { get; set; }
+        public string Level { get; set; }
+    }
+}

--- a/src/DbUpdatePortal/Configuration/StartupSecretsConfig.cs
+++ b/src/DbUpdatePortal/Configuration/StartupSecretsConfig.cs
@@ -1,0 +1,12 @@
+﻿namespace DbUpdatePortal.Configuration
+{
+    public class StartupSecretsConfig
+    {
+        public string DataSource { get; set; }
+        public string UserId { get; set; }
+        public string Password { get; set; }
+        public string SqlLoggingUsername { get; set; }
+        public string SqlLoggingPassword { get; set; }
+        public string ClientAzureAdSecret { get; set; }
+    }
+}

--- a/src/DbUpdatePortal/Configuration/UriConfig.cs
+++ b/src/DbUpdatePortal/Configuration/UriConfig.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace DbUpdatePortal.Configuration
+{
+    public class UriConfig
+    {
+
+        public Uri DbUpdateLocalDevLandingPageHttpsUrl { get; set; }
+        public Uri DbUpdateLandingPageUrl { get; set; }
+
+    }
+}

--- a/src/DbUpdatePortal/Data/ChartingAreas.json
+++ b/src/DbUpdatePortal/Data/ChartingAreas.json
@@ -1,0 +1,17 @@
+[
+
+  {
+    "ChartingAreaId": 1,
+    "Name": "Home waters"
+  },
+  {
+    "ChartingAreaId": 2,
+    "Name": "National responsibility"
+  },
+  {
+    "ChartingAreaId": 3,
+    "Name": "Primary charting"
+  }
+
+
+]

--- a/src/DbUpdatePortal/Data/HpdUsers.json
+++ b/src/DbUpdatePortal/Data/HpdUsers.json
@@ -1,0 +1,42 @@
+[
+  {
+    "AdUsername": "Greg Williams",
+    "HpdUsername": "TM_User"
+  },
+  {
+    "AdUsername": "Samir Hasson",
+    "HpdUsername": "TM_User"
+  },
+  {
+    "AdUsername": "Ben Hall",
+    "HpdUsername": "TM_User"
+  },
+  {
+    "AdUsername": "Rossall Sandford",
+    "HpdUsername": "TM_User"
+  },
+  {
+    "AdUsername": "Bonnie Poole",
+    "HpdUsername": "TM_User"
+  },
+  {
+    "AdUsername": "Gareth Evans",
+    "HpdUsername": "TM_User"
+  },
+  {
+    "AdUsername": "Matthew Stoodley",
+    "HpdUsername": "TM_User"
+  },
+  {
+    "AdUsername": "Peter Bates",
+    "HpdUsername": "TM_User"
+  },
+  {
+    "AdUsername": "Rajan Shunmuga",
+    "HpdUsername": "TM_User"
+  },
+  {
+    "AdUsername": "Stuart Barzey",
+    "HpdUsername" :  "TM_User" 
+  }
+]

--- a/src/DbUpdatePortal/Data/TaskInfo.json
+++ b/src/DbUpdatePortal/Data/TaskInfo.json
@@ -1,0 +1,74 @@
+[
+  {
+    "Name": "Name",
+    "chartingArea": "Home Waters",
+    "UpdateType": "Update Type",
+    "TargetDate": "2020-01-10T00:00:00",
+    "AssignedUser": "SVC_TMNCNEPrtlUITest",
+    "AssignedDate": "2020-01-06",
+    "Status": "InProgress",
+  
+    "TaskRole": {
+      "compiler": "Amanda Bowery",
+      "verifier": "StoodleyM"
+    },
+    "TaskNote": {
+      "Text": "Important note on first task",
+      "Created": "2020-01-10T00:00:00",
+      "CreatedByUsername": "StoodleyM",
+      "LastModified": "2020-01-10T00:00:00",
+      "LastModifiedByUsername": "StoodleyM"
+    },
+    "TaskComment": [
+      {
+        "Comment": "This is a very important comment that will eventually reach a, not insignificant character count",
+        "Username": "StoodleyM",
+        "Created": "2020-01-28T00:00:00",
+        "ActionIndicator": false,
+        "ActionRole": null
+      },
+      {
+        "Comment": "",
+        "Username": "StoodleyM",
+        "Created": "2020-01-28T00:00:00",
+        "ActionIndicator": true,
+        "ActionRole": "Compiler"
+      }
+    ],
+
+    "TaskStage": [
+      {
+        "TaskStageTypeId": 1,
+        "DateExpected": null,
+        "DateCompleted": "2020-01-15T00:00:00",
+        "Status": "Completed",
+        "TaskStageComment": [
+          {
+            "Comment": "First comment for Compilation stage",
+            "Username": "Amanda Bowery",
+            "Created": "2020-01-15T12:32:32"
+          },
+          {
+            "Comment": "One more comment on Compilation stage",
+            "Username": "Amanda Bowery",
+            "Created": "2020-01-15T12:32:32"
+          }
+        ]
+
+      },
+      {
+        "TaskStageTypeId": 2,
+        "DateExpected": null,
+        "DateCompleted": null,
+        "Status": "InProgress"
+      },
+      {
+        "TaskStageTypeId": 3,
+        "DateExpected": null,
+        "DateCompleted": null,
+        "Status": "Open"
+      }
+    ]
+
+  }
+]

--- a/src/DbUpdatePortal/Data/TaskStageType.json
+++ b/src/DbUpdatePortal/Data/TaskStageType.json
@@ -1,0 +1,32 @@
+[
+ {
+    "TaskStageTypeId": 1,
+    "Name": "Compile Chart",
+    "SequenceNumber": 1,
+    "AllowRework": false
+  },
+  {
+    "TaskStageTypeId": 2,
+    "Name": "V1",
+    "SequenceNumber": 2,
+    "AllowRework": true
+  },
+  {
+    "TaskStageTypeId": 3,
+    "Name": "V1 Rework",
+    "SequenceNumber": 3,
+    "AllowRework": false
+  },
+  {
+    "TaskStageTypeId": 4,
+    "Name": "CPT",
+    "SequenceNumber": 4,
+    "AllowRework": false
+  },
+  {
+    "TaskStageTypeId": 5,
+    "Name": "DCPT",
+    "SequenceNumber": 5,
+    "AllowRework": false
+  }
+]

--- a/src/DbUpdatePortal/Data/UpdateTypes.json
+++ b/src/DbUpdatePortal/Data/UpdateTypes.json
@@ -1,0 +1,22 @@
+[
+  {
+    "UpdateTypeId": 1,
+    "Name": "Steady state"
+  },
+  {
+    "UpdateTypeId": 2,
+    "Name": "Update from source"
+  },
+  {
+    "UpdateTypeId": 3,
+    "Name": "Initial population"
+  },
+  {
+    "UpdateTypeId": 4,
+    "Name": "Wrecks"
+  },
+  {
+    "UpdateTypeId": 5,
+    "Name": "Continuous improvement"
+  }
+]

--- a/src/DbUpdatePortal/Data/Users.json
+++ b/src/DbUpdatePortal/Data/Users.json
@@ -1,0 +1,7 @@
+[
+  {
+    "DisplayName": "SVC_TMNCNEPrtlUITest",
+    "UserPrincipalName": "SVC_TMNCNEPrtlUITest@ukho.gov.uk",
+    "LastCheckedDate": "2020-01-10T00:00:00"
+  }
+]

--- a/src/DbUpdatePortal/DbUpdatePortal.csproj
+++ b/src/DbUpdatePortal/DbUpdatePortal.csproj
@@ -1,7 +1,18 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="3.1.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
+    <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Common.Helpers\Common.Helpers.csproj" />
+    <ProjectReference Include="..\Databases\DbUpdateWorkflowDatabase.EF\DbUpdateWorkflowDatabase.EF.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/DbUpdatePortal/HostedServices/AdUserUpdateService.cs
+++ b/src/DbUpdatePortal/HostedServices/AdUserUpdateService.cs
@@ -1,0 +1,109 @@
+﻿using Common.Helpers.Auth;
+using DbUpdatePortal.Configuration;
+using DbUpdateWorkflowDatabase.EF;
+using DbUpdateWorkflowDatabase.EF.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Serilog.Context;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DbUpdatePortal.HostedServices
+{
+    public class AdUserUpdateService : BackgroundService
+    {
+        private readonly ILogger<AdUserUpdateService> _logger;
+        private readonly IAdDirectoryService _adDirectoryService;
+        private readonly AdUserUpdateServiceSecrets _secrets;
+        private readonly TimeSpan _updateIntervalSeconds;
+
+        // Hosted service is singleton so we need to safely consume our scoped services
+        private readonly IServiceScopeFactory _serviceScopeFactory;
+
+        public AdUserUpdateService(ILogger<AdUserUpdateService> logger,
+            IOptions<AdUserUpdateServiceConfig> config,
+            IOptions<AdUserUpdateServiceSecrets> secrets,
+            IAdDirectoryService adDirectoryService,
+            IServiceScopeFactory serviceScopeFactory)
+        {
+            _logger = logger;
+            _adDirectoryService = adDirectoryService;
+            _secrets = secrets.Value;
+            _serviceScopeFactory = serviceScopeFactory;
+
+            _updateIntervalSeconds = TimeSpan.FromSeconds(config.Value.AdUpdateIntervalSeconds > 0
+                ? config.Value.AdUpdateIntervalSeconds
+                : 3600);
+
+            LogContext.PushProperty("AdUserUpdateService", nameof(AdUserUpdateService));
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            _logger.LogInformation($"{nameof(AdUserUpdateService)}: Starting with interval of {_updateIntervalSeconds} seconds.");
+
+            stoppingToken.Register(() =>
+                _logger.LogInformation($"{nameof(AdUserUpdateService)}: Stopping (received cancellation token)."));
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await UpdateDbFromAdAsync();
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, $"{nameof(AdUserUpdateService)}: Failed to update users from AD.");
+                }
+
+                await Task.Delay(_updateIntervalSeconds, stoppingToken);
+            }
+
+            _logger.LogInformation($"{nameof(AdUserUpdateService)}: Stopping.");
+        }
+
+        private async Task UpdateDbFromAdAsync()
+        {
+            var adGroupMembers =
+                await _adDirectoryService.GetGroupMembersFromAdAsync(ExtractGuidsFromStr(_secrets.AdUserGroups));
+
+            using var scope = _serviceScopeFactory.CreateScope();
+            var workflowDbContext = scope.ServiceProvider.GetRequiredService<DbUpdateWorkflowDbContext>();
+
+            var currentAdUsers = await workflowDbContext.AdUser.ToListAsync();
+
+            var newAdUsers = adGroupMembers.Where(m =>
+                currentAdUsers.All(c => c.UserPrincipalName != m.UserPrincipalName)).Select(n => new AdUser
+                {
+                    DisplayName = n.DisplayName,
+                    UserPrincipalName = n.UserPrincipalName,
+                    // TODO hook into checks
+                    LastCheckedDate = DateTime.UtcNow
+                }).ToList(); // avoid multiple iterations for counting with ToList()
+
+            if (newAdUsers.Count > 0) _logger.LogInformation($"{nameof(AdUserUpdateService)}: {newAdUsers.Count} new users added to database from AD.");
+
+            workflowDbContext.AdUser.AddRange(newAdUsers);
+
+            await workflowDbContext.SaveChangesAsync();
+        }
+
+        private IEnumerable<Guid> ExtractGuidsFromStr(string adUserGroups)
+        {
+            var guidCollection = adUserGroups.Split(',')
+                    .Where(x => Guid.TryParse(x, out _))
+                    .Select(Guid.Parse).ToList();
+
+            var diff = guidCollection.Count - _secrets.AdUserGroups.Length;
+            if (diff > 0) _logger.LogWarning($"{nameof(AdUserUpdateService)}: {diff} invalid GUIDs supplied in configuration.");
+
+            return guidCollection;
+        }
+    }
+}

--- a/src/DbUpdatePortal/HostedServices/DatabaseSeedingService.cs
+++ b/src/DbUpdatePortal/HostedServices/DatabaseSeedingService.cs
@@ -1,0 +1,33 @@
+﻿using Common.Helpers;
+using DbUpdateWorkflowDatabase.EF;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DbUpdatePortal.HostedServices
+{
+    public class DatabaseSeedingService : IHostedService
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public DatabaseSeedingService(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var workflowDbContext = scope.ServiceProvider.GetRequiredService<DbUpdateWorkflowDbContext>();
+
+            DbUpdateWorkflowDatabaseSeeder.UsingDbContext(workflowDbContext).PopulateTables().SaveChanges();
+
+            return Task.CompletedTask;
+        }
+
+        // Not required
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/src/DbUpdatePortal/LoggingHelper.cs
+++ b/src/DbUpdatePortal/LoggingHelper.cs
@@ -1,0 +1,62 @@
+﻿using Common.Helpers;
+using DbUpdatePortal.Configuration;
+using Serilog;
+using Serilog.Events;
+using Serilog.Sinks.MSSqlServer;
+using Serilog.Sinks.MSSqlServer.Sinks.MSSqlServer.Options;
+using System;
+using System.Collections.ObjectModel;
+using System.Data;
+
+namespace DbUpdatePortal
+{
+
+    public class LoggingHelper
+    {
+        public static void SetupLogging(bool isLocalDb, StartupLoggingConfig startupLoggingConfig,
+            StartupSecretsConfig startupSecretsConfig)
+        {
+            var loggingConnectionString = DatabasesHelpers.BuildSqlConnectionString(
+                isLocalDb,
+                isLocalDb ? startupLoggingConfig.LocalDbServer : startupLoggingConfig.WorkflowDbServer,
+                isLocalDb ? startupLoggingConfig.LocalDbName : startupLoggingConfig.WorkflowDbName,
+                startupSecretsConfig.SqlLoggingUsername, startupSecretsConfig.SqlLoggingPassword
+            );
+
+            Enum.TryParse(startupLoggingConfig.Level, out LogEventLevel logLevel);
+
+            var columnOptions = new ColumnOptions
+            {
+                AdditionalColumns = new Collection<SqlColumn>
+                {
+                    new SqlColumn
+                        {ColumnName = "UserFullName", DataType = SqlDbType.NVarChar, DataLength = 255},
+                    new SqlColumn
+                        {ColumnName = "ProcessId", DataType = SqlDbType.Int},
+                    new SqlColumn
+                        {ColumnName = "ActivityName", DataType = SqlDbType.NVarChar, DataLength = 100},
+                    new SqlColumn
+                        {ColumnName = "DbUpdatePortalResource", DataType = SqlDbType.NVarChar, DataLength = 255}
+                }
+            };
+
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Is(logLevel)
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+                .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
+                .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning)
+                .Enrich.FromLogContext()
+                .WriteTo.Console()
+                .WriteTo.MSSqlServer(
+                    connectionString: loggingConnectionString,
+                    sinkOptions: new SinkOptions
+                    {
+                        TableName = "LoggingDbUpdatePortal",
+                        AutoCreateSqlTable = true
+
+                    },
+                    columnOptions: columnOptions)
+                .CreateLogger();
+        }
+    }
+}

--- a/src/DbUpdatePortal/Pages/Index.cshtml.cs
+++ b/src/DbUpdatePortal/Pages/Index.cshtml.cs
@@ -1,15 +1,48 @@
-﻿using Microsoft.AspNetCore.Mvc.RazorPages;
+﻿using Common.Helpers.Auth;
+using DbUpdatePortal.Auth;
+using DbUpdateWorkflowDatabase.EF;
+using DbUpdateWorkflowDatabase.EF.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+
 
 namespace DbUpdatePortal.Pages
 {
+    //[Authorize]
     public class IndexModel : PageModel
     {
+       // private readonly IDbUpdateUserDbService _dbUpdateUserDbService;
+        private readonly DbUpdateWorkflowDbContext _dbContext;
         private readonly ILogger<IndexModel> _logger;
 
-        public IndexModel(ILogger<IndexModel> logger)
+        //private readonly IAdDirectoryService _adDirectoryService;
+
+        private (string DisplayName, string UserPrincipalName) _currentUser;
+        //public (string DisplayName, string UserPrincipalName) CurrentUser
+        //{
+        //    get
+        //    {
+        //        if (_currentUser == default) _currentUser = _adDirectoryService.GetUserDetails(this.User);
+        //        return _currentUser;
+        //    }
+        //}
+        [BindProperty(SupportsGet = true)]
+        public List<TaskInfo> DbUpdateTasks { get; set; }
+
+
+        public IndexModel(//IDbUpdateUserDbService dbUpdateUserDbService,
+                          DbUpdateWorkflowDbContext dbContext,
+                          ILogger<IndexModel> logger
+                          //,IAdDirectoryService adDirectoryService
+                          )
         {
+           // _dbUpdateUserDbService = dbUpdateUserDbService;
+            _dbContext = dbContext;
             _logger = logger;
+            //_adDirectoryService = adDirectoryService;
         }
 
         public void OnGet()

--- a/src/DbUpdatePortal/Program.cs
+++ b/src/DbUpdatePortal/Program.cs
@@ -1,5 +1,10 @@
+using Common.Helpers;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.AzureKeyVault;
 using Microsoft.Extensions.Hosting;
+using Serilog;
+using System;
 
 namespace DbUpdatePortal
 {
@@ -7,14 +12,34 @@ namespace DbUpdatePortal
     {
         public static void Main(string[] args)
         {
-            CreateHostBuilder(args).Build().Run();
+            try
+            {
+                CreateHostBuilder(args).Build().Run();
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex, "Host terminated unexpectedly");
+            }
+            finally
+            {
+                Log.CloseAndFlush();
+            }
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
-                .ConfigureWebHostDefaults(webBuilder =>
+                .UseEnvironment(ConfigHelpers.HostBuilderEnvironment)
+                .UseSerilog()
+                .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); })
+                .ConfigureAppConfiguration(builder =>
                 {
-                    webBuilder.UseStartup<Startup>();
+                    var azureAppConfConnectionString =
+                        Environment.GetEnvironmentVariable("AZURE_APP_CONFIGURATION_CONNECTION_STRING");
+
+                    var (keyVaultAddress, keyVaultClient) = SecretsHelpers.SetUpKeyVaultClient();
+
+                    builder.AddAzureAppConfiguration(azureAppConfConnectionString)
+                        .AddAzureKeyVault(keyVaultAddress, keyVaultClient, new DefaultKeyVaultSecretManager()).Build();
                 });
     }
 }

--- a/src/DbUpdatePortal/Startup.cs
+++ b/src/DbUpdatePortal/Startup.cs
@@ -1,9 +1,23 @@
+using Common.Helpers;
+using DbUpdatePortal.Configuration;
 using DbUpdatePortal.Helpers;
+using DbUpdateWorkflowDatabase.EF;
+using HpdDatabase.EF.Models;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Graph;
+using Serilog;
+using Serilog.Events;
+using System.Collections.Generic;
+using System.Globalization;
+using DbUpdatePortal.HostedServices;
 
 namespace DbUpdatePortal
 {
@@ -19,14 +33,127 @@ namespace DbUpdatePortal
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            var isLocalDevelopment = ConfigHelpers.IsLocalDevelopment;
+
+            var startupLoggingConfig = new StartupLoggingConfig();
+            Configuration.GetSection("logging").Bind(startupLoggingConfig);
+
+            var startupSecretsConfig = new StartupSecretsConfig();
+            Configuration.GetSection("LoggingDbSection").Bind(startupSecretsConfig);
+
+            LoggingHelper.SetupLogging(isLocalDevelopment, startupLoggingConfig, startupSecretsConfig);
+
+            services.Configure<RequestLocalizationOptions>(options =>
+            {
+                options.DefaultRequestCulture = new Microsoft.AspNetCore.Localization.RequestCulture("en-GB");
+                options.SupportedCultures = new List<CultureInfo> { new CultureInfo("en-GB"), new CultureInfo("en-GB") };
+            });
+
+            services.AddOptions<GeneralConfig>()
+                .Bind(Configuration.GetSection("dbupgradeportal"))
+                .Bind(Configuration.GetSection("subscription"))
+                .Bind(Configuration.GetSection("caris"));
+            services.AddOptions<UriConfig>()
+                .Bind(Configuration.GetSection("urls"));
+            services.AddOptions<StartupSecretsConfig>()
+                .Bind(Configuration.GetSection("DbUpdatePortalSection"));
+
             services.AddRazorPages();
+            services.AddHealthChecks();
+
+            var startupConfig = new StartupConfig();
+            Configuration.GetSection("urls").Bind(startupConfig);
+            Configuration.GetSection("databases").Bind(startupConfig);
+            Configuration.GetSection("subscription").Bind(startupConfig);
+            Configuration.GetSection("dbupdateportal").Bind(startupConfig);
+
+            //services.AddOptions<AdUserUpdateServiceConfig>()
+            //    .Bind(Configuration.GetSection("dbupdateportal"));
+            //services.AddOptions<AdUserUpdateServiceSecrets>()
+            //    .Bind(Configuration.GetSection("DbUpdateActiveDirectory"));
+
+            // Use a singleton Microsoft.Graph.HttpProvider to avoid same issues HttpClient once suffered from
+            services.AddSingleton<IHttpProvider, HttpProvider>();
+
+
+            // TODO - refactor all GetService away
+            //services.AddSingleton<IAdDirectoryService,
+            //    AdDirectoryService>(s => new AdDirectoryService(
+            //    s.GetService<IOptions<StartupSecretsConfig>>().Value.ClientAzureAdSecret,
+            //    s.GetService<IOptions<GeneralConfig>>().Value.AzureAdClientId,
+            //    s.GetService<IOptions<GeneralConfig>>().Value.TenantId,
+            //    isLocalDevelopment
+            //        ? s.GetService<IOptions<UriConfig>>().Value.DbUpdateLocalDevLandingPageHttpsUrl
+            //        : s.GetService<IOptions<UriConfig>>().Value.DbUpdateLandingPageUrl,
+            //    s.GetService<HttpProvider>()));
+
 
             services.AddSingleton<AppVersionInfo>();
+
+            //services.AddScoped<IDbUpdateUserDbService,
+            //    DbUpdateUserDbService>(s => new DbUpdateUserDbService(s.GetService<DbUpdateWorkflowDbContext>(), s.GetService<IAdDirectoryService>()));
+
+            //services.AddScoped<IDbUpdateUserDbService, DbUpdateUserDbService>();
+
+            // Order of these two is important
+            if (ConfigHelpers.IsLocalDevelopment || ConfigHelpers.IsAzureUat)
+                services.AddHostedService<DatabaseSeedingService>();
+            //services.AddHostedService<AdUserUpdateService>();
+
+
+            services.AddAuthentication(AzureADDefaults.AuthenticationScheme)
+                .AddAzureAD(options =>
+                {
+                    options.ClientId = startupConfig.AzureAdClientId;
+                    options.Instance = "https://ukho.onmicrosoft.com";
+                    options.CallbackPath = "/signin-oidc";
+                    options.TenantId = startupConfig.TenantId;
+                    options.Domain = "ukho.onmicrosoft.com";
+
+                });
+
+            services.Configure<OpenIdConnectOptions>(AzureADDefaults.OpenIdScheme, options =>
+            {
+                options.Authority = $"https://login.microsoftonline.com/{startupConfig.TenantId}/v2.0/";
+                options.TokenValidationParameters.ValidateIssuer = false; // accept several tenants (here simplified for development - TODO)
+            });
+
+
+            var workflowDbConnectionString = DatabasesHelpers.BuildSqlConnectionString(isLocalDevelopment,
+                isLocalDevelopment ? startupConfig.LocalDbServer : startupConfig.WorkflowDbServer, startupConfig.DbUpdateWorkflowDbName);
+
+            services.AddDbContext<DbUpdateWorkflowDbContext>((serviceProvider, options) =>
+                options.UseSqlServer(workflowDbConnectionString));
+
+            var startupSecretConfig = new StartupSecretsConfig();
+            Configuration.GetSection("K2RestApi").Bind(startupSecretConfig);
+            Configuration.GetSection("HpdDbSection").Bind(startupSecretConfig);
+
+            var hpdConnection = DatabasesHelpers.BuildOracleConnectionString(startupSecretConfig.DataSource,
+                startupSecretConfig.UserId, startupSecretConfig.Password);
+
+            services.AddDbContext<HpdDbContext>((serviceProvider, options) =>
+                options.UseOracle(hpdConnection));
+
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env,
+            DbUpdateWorkflowDbContext dbUpdateWorkflowDbContext)
         {
+            app.UseSerilogRequestLogging(
+                options =>
+                    options.GetLevel = (ctx, d, ex) =>
+                    {
+                        if (ex == null && ctx.Response.StatusCode <= 499)
+                        {
+                            return LogEventLevel.Verbose;
+                        }
+
+                        return LogEventLevel.Error;
+                    }
+            );
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();


### PR DESCRIPTION
Following changes are done
1. Serilog logging is added into the same database in a different table called LoggingDbUpdatePortal
2. Seeding data and the associated hosted service are added
3. Services and code associated with the Active Directory users are commented and will be implemented during the Landing page story.