### PR TITLE
Set On Hold switch back to label type

### DIFF
--- a/src/Portal/Portal/Pages/DbAssessment/_TaskInformation.cshtml
+++ b/src/Portal/Portal/Pages/DbAssessment/_TaskInformation.cshtml
@@ -34,10 +34,10 @@
                         <div class="form-group row justify-content-between">
                             <div class="col-5 p-0">@Html.LabelFor(model => model.OnHoldDays)</div>
                             <div class="col-7" style="padding-left: 0;">
-                                <div class="switch ml-2 mb-auto">
+                                <label class="switch ml-2 mb-auto">
                                     <input type="checkbox" id="onHoldToggle" name="IsOnHold" class="success" @(Model.IsOnHold ? "checked" : "") value="true" aria-label="On Hold">
                                     <span class="slider"></span>
-                                </div>
+                                </label>
                                 @Html.DisplayFor(model => model.OnHoldDays)&nbsp;
 
                                 @if (Model.IsOnHold)


### PR DESCRIPTION
- Fix the On Hold switch on the TaskInformation partial by changing it back to a label element