### PR TITLE
Features/improve handling of no assessment data

### DIFF
--- a/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml.cs
@@ -259,7 +259,7 @@ namespace Portal.Pages.DbAssessment
                 SourceDocumentName = sourceDocumentData.Name,
                 ReceiptDate = sourceDocumentData.ReceiptDate,
                 SourceDocumentType = sourceDocumentData.DocumentType,
-                SourceNature = sourceDocumentData.SourceName,
+                SourceNature = sourceDocumentData.DocumentNature,
                 Datum = sourceDocumentData.Datum,
                 Status = SourceDocumentRetrievalStatus.Started.ToString(),
                 Created = DateTime.Now,

--- a/src/Portal/Portal/Pages/Index.cshtml
+++ b/src/Portal/Portal/Pages/Index.cshtml
@@ -91,11 +91,11 @@
                             </span>
                         </td>
                         <td>
-                            @task.AssessmentDataRsdraNumber
+                            @Html.DisplayFor(m => task.AssessmentDataRsdraNumber)
                         </td>
                         <td>
                             <span class="overflowElipsis" style="max-width: 10rem;" title="@task.AssessmentDataSourceDocumentName">
-                                @task.AssessmentDataSourceDocumentName
+                                @Html.DisplayFor(m => task.AssessmentDataSourceDocumentName)
                             </span>
                         </td>
                         <td>
@@ -185,11 +185,11 @@
                             </span>
                         </td>
                         <td>
-                            @task.AssessmentDataRsdraNumber
+                            @Html.DisplayFor(m => task.AssessmentDataRsdraNumber)
                         </td>
                         <td>
                             <span class="overflowElipsis" style="max-width: 10rem;" title="@task.AssessmentDataSourceDocumentName">
-                                @task.AssessmentDataSourceDocumentName
+                                @Html.DisplayFor(m => task.AssessmentDataSourceDocumentName)
                             </span>
                         </td>
                         <td>

--- a/src/Portal/Portal/Pages/Index.cshtml.cs
+++ b/src/Portal/Portal/Pages/Index.cshtml.cs
@@ -86,6 +86,7 @@ namespace Portal.Pages
                 .Include(vd => vd.DbAssessmentVerifyData)
                 .Include(t => t.TaskNote)
                 .Include(o => o.OnHold)
+                .AsNoTracking()
                 .Where(wi => wi.Status == WorkflowStatus.Started.ToString())
                 .OrderBy(wi => wi.ProcessId)
                 .ToListAsync();
@@ -106,7 +107,7 @@ namespace Portal.Pages
 
                 var taskType = GetTaskType(instance);
 
-                if (instance.AssessmentData.EffectiveStartDate.HasValue)
+                if (instance.AssessmentData?.EffectiveStartDate != null)
                 {
                     var result = _indexFacade.CalculateDmEndDate(
                         instance.AssessmentData.EffectiveStartDate.Value,

--- a/src/Portal/Portal/ViewModels/TaskViewModel.cs
+++ b/src/Portal/Portal/ViewModels/TaskViewModel.cs
@@ -20,7 +20,9 @@ namespace Portal.ViewModels
         public bool OnHoldDaysGreen { get; set; }
         public bool OnHoldDaysRed { get; set; }
         public int OnHoldDays { get; set; }
+        [DisplayFormat(NullDisplayText = "N/A")]
         public string AssessmentDataRsdraNumber { get; set; }
+        [DisplayFormat(NullDisplayText = "N/A")]
         public string AssessmentDataSourceDocumentName { get; set; }
         public string Workspace { get; set; }
         public string TaskStage { get; set; }


### PR DESCRIPTION
## Portal

- Index, TaskViewModel, _SourceDocumentDetails:
  - Now we are displaying tasks even when failed to get assessment data from SDRA. Show N/A under relevant columns when that occurs