### PR TITLE
Features/fix data services put document as assessed parameters

### DIFF
--- a/src/DataServices/DataServices/Controllers/AssessmentApi.cs
+++ b/src/DataServices/DataServices/Controllers/AssessmentApi.cs
@@ -192,7 +192,7 @@ namespace DataServices.Controllers
         /// <response code="406">Not acceptable.</response>
         /// <response code="500">Internal Server Error.</response>
         [HttpPut]
-        [Route("/DataServices/v1/SourceDocument/Assessment/DocumentAssessed/{callerCode}/{transactionId}/{sdocId}/{actionType}/{change}")]
+        [Route("/DataServices/v1/SourceDocument/Assessment/DocumentAssessed/{callerCode}/{transactionId}/{sdocId}/{actionType}")]
         [ValidateModelState]
         [SwaggerOperation("PutDocumentAsAssessed")]
         [SwaggerResponse(statusCode: 400, type: typeof(DefaultErrorResponse), description: "Bad request.")]
@@ -206,7 +206,7 @@ namespace DataServices.Controllers
                                                             [FromRoute][Required]string transactionId,
                                                             [FromRoute][Required]int? sdocId,
                                                             [FromRoute][Required]string actionType, 
-                                                            [FromRoute][Required]string change)
+                                                            [FromQuery][Required]string change)
         {
 
             LogContext.PushProperty("ApiResource", nameof(PutDocumentAsAssessed));

--- a/src/DataServices/DataServices/wwwroot/swagger-original.json
+++ b/src/DataServices/DataServices/wwwroot/swagger-original.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "SDRA API",
     "description": "This API is for SDRA\n\nIt provides Source Document Assessment Data and Data Access\n",
-    "version": "1.1.4"
+    "version": "1.1.5"
   },
   "servers": [
     {
@@ -105,7 +105,7 @@
         }
       }
     },
-    "/SourceDocument/Assessment/DocumentAssessed/{callerCode}/{transactionId}/{sdocId}/{action}/{change}": {
+    "/SourceDocument/Assessment/DocumentAssessed/{callerCode}/{transactionId}/{sdocId}/{action}": {
       "put": {
         "tags": [
           "Assessment"
@@ -166,10 +166,10 @@
           },
           {
             "name": "change",
-            "in": "path",
-            "description": "tbc\n\nExample: tbc\n",
+            "in": "query",
+            "description": "Change comment for Record product action\n\nExample: tbc\n",
             "required": true,
-            "style": "simple",
+            "style": "form",
             "explode": false,
             "schema": {
               "type": "string"

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Config/UriConfig.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Config/UriConfig.cs
@@ -43,7 +43,7 @@ namespace WorkflowCoordinator.Config
         {
             return new Uri(
                 ConfigHelpers.IsLocalDevelopment ? DataAccessLocalhostBaseUri : DataServicesWebServiceBaseUri,
-                $@"{DataServicesWebServiceAssessmentAssessedUri}{callerCode}/{transactionId}/{sdocId}/{actionType}/{change}");
+                $@"{DataServicesWebServiceAssessmentAssessedUri}{callerCode}/{transactionId}/{sdocId}/{actionType}?change={Uri.EscapeDataString(change)}");
         }
         
         public Uri BuildPcpEventServiceUri(string eventName)


### PR DESCRIPTION
## DataServices

- AssessmentApi, swagger-original.json: Converted 'change' parameter to be FromQuery for PutDocumentAsAssessed

## WorkflowCoordinator

- UriConfig: Converted 'change' parameter to be a Query within the url for marking document as Assessed
