### PR TITLE
Features/db tests for adusers fk

### DIFF
--- a/src/Databases/WorkflowDatabase.Tests/AdUserTests/CarisProjectDetailsTests.cs
+++ b/src/Databases/WorkflowDatabase.Tests/AdUserTests/CarisProjectDetailsTests.cs
@@ -1,0 +1,53 @@
+using System;
+using Common.Helpers;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using WorkflowDatabase.EF;
+using WorkflowDatabase.EF.Models;
+using WorkflowDatabase.Tests.Helpers;
+
+namespace WorkflowDatabase.Tests.AdUserTests
+{
+    public class CarisProjectDetailsTests
+    {
+        private WorkflowDbContext _dbContext;
+        private AdUser TestUser1 { get; set; }
+        private AdUser TestUser2 { get; set; }
+        private WorkflowInstance SkeletonWorkflowInstance { get; set; }
+
+        [SetUp]
+        public void Setup()
+        {
+            _dbContext = TestSetupHelper.CreateWorkflowDbContext();
+            DatabasesHelpers.ClearWorkflowDbTables(_dbContext);
+
+            TestUser1 = AdUserHelper.CreateTestUser(_dbContext);
+            TestUser2 = AdUserHelper.CreateTestUser(_dbContext, 2);
+
+            SkeletonWorkflowInstance = AdUserHelper.CreateSkeletonWorkflowInstance(_dbContext);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            _dbContext.Dispose();
+        }
+
+        [Test]
+        public void Carisprojectdetails_table_prevents_unknown_CreatedByAdUser_due_to_FK()
+        {
+            _dbContext.CarisProjectDetails.Add(new CarisProjectDetails
+            {
+                ProcessId = SkeletonWorkflowInstance.ProcessId,
+                ProjectId = 1,
+                ProjectName = string.Empty,
+                Created = DateTime.Now,
+                CreatedByAdUserId = 3
+            });
+
+            var ex = Assert.Throws<DbUpdateException>(() => _dbContext.SaveChanges());
+            Assert.That(ex.InnerException.Message.Contains("The INSERT statement conflicted with the FOREIGN KEY constraint", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}
+

--- a/src/Databases/WorkflowDatabase.Tests/AdUserTests/CommentsTests.cs
+++ b/src/Databases/WorkflowDatabase.Tests/AdUserTests/CommentsTests.cs
@@ -1,0 +1,53 @@
+using System;
+using Common.Helpers;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using WorkflowDatabase.EF;
+using WorkflowDatabase.EF.Models;
+using WorkflowDatabase.Tests.Helpers;
+
+namespace WorkflowDatabase.Tests.AdUserTests
+{
+    public class CommentsTests
+    {
+        private WorkflowDbContext _dbContext;
+        private AdUser TestUser1 { get; set; }
+        private AdUser TestUser2 { get; set; }
+        private WorkflowInstance SkeletonWorkflowInstance { get; set; }
+
+        [SetUp]
+        public void Setup()
+        {
+            _dbContext = TestSetupHelper.CreateWorkflowDbContext();
+            DatabasesHelpers.ClearWorkflowDbTables(_dbContext);
+
+            TestUser1 = AdUserHelper.CreateTestUser(_dbContext);
+            TestUser2 = AdUserHelper.CreateTestUser(_dbContext, 2);
+
+            SkeletonWorkflowInstance = AdUserHelper.CreateSkeletonWorkflowInstance(_dbContext);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            _dbContext.Dispose();
+        }
+
+        [Test]
+        public void Comments_table_prevents_unknown_AdUser_due_to_FK()
+        {
+            _dbContext.Comments.Add(new Comment
+            {
+                WorkflowInstanceId = SkeletonWorkflowInstance.WorkflowInstanceId,
+                ProcessId = SkeletonWorkflowInstance.ProcessId,
+                Text = string.Empty,
+                Created = DateTime.Now,
+                AdUserId = 3
+            });
+
+            var ex = Assert.Throws<DbUpdateException>(() => _dbContext.SaveChanges());
+            Assert.That(ex.InnerException.Message.Contains("The INSERT statement conflicted with the FOREIGN KEY constraint", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}
+

--- a/src/Databases/WorkflowDatabase.Tests/AdUserTests/DbAssessmentAssessTests.cs
+++ b/src/Databases/WorkflowDatabase.Tests/AdUserTests/DbAssessmentAssessTests.cs
@@ -34,7 +34,7 @@ namespace WorkflowDatabase.Tests.AdUserTests
         }
 
         [Test]
-        public void Dbassessmentreviewdata_table_prevents_unknown_revieweraduser_due_to_FK()
+        public void Dbassessmentassessdata_table_prevents_unknown_revieweraduser_due_to_FK()
         {
             _dbContext.DbAssessmentAssessData.Add(new DbAssessmentAssessData
             {
@@ -47,7 +47,7 @@ namespace WorkflowDatabase.Tests.AdUserTests
         }
 
         [Test]
-        public void Dbassessmentreviewdata_table_prevents_unknown_assessoraduser_due_to_FK()
+        public void Dbassessmentassessdata_table_prevents_unknown_assessoraduser_due_to_FK()
         {
             _dbContext.DbAssessmentAssessData.Add(new DbAssessmentAssessData
             {
@@ -60,7 +60,7 @@ namespace WorkflowDatabase.Tests.AdUserTests
         }
 
         [Test]
-        public void Dbassessmentreviewdata_table_prevents_unknown_verifieraduser_due_to_FK()
+        public void Dbassessmentassessdata_table_prevents_unknown_verifieraduser_due_to_FK()
         {
             _dbContext.DbAssessmentAssessData.Add(new DbAssessmentAssessData
             {

--- a/src/Databases/WorkflowDatabase.Tests/AdUserTests/DbAssessmentAssessTests.cs
+++ b/src/Databases/WorkflowDatabase.Tests/AdUserTests/DbAssessmentAssessTests.cs
@@ -1,0 +1,76 @@
+using System;
+using Common.Helpers;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using WorkflowDatabase.EF;
+using WorkflowDatabase.EF.Models;
+using WorkflowDatabase.Tests.Helpers;
+
+namespace WorkflowDatabase.Tests.AdUserTests
+{
+    public class DbAssessmentAssessTests
+    {
+        private WorkflowDbContext _dbContext;
+        private AdUser TestUser1 { get; set; }
+        private AdUser TestUser2 { get; set; }
+        private WorkflowInstance SkeletonWorkflowInstance { get; set; }
+
+        [SetUp]
+        public void Setup()
+        {
+            _dbContext = TestSetupHelper.CreateWorkflowDbContext();
+            DatabasesHelpers.ClearWorkflowDbTables(_dbContext);
+
+            TestUser1 = AdUserHelper.CreateTestUser(_dbContext);
+            TestUser2 = AdUserHelper.CreateTestUser(_dbContext, 2);
+
+            SkeletonWorkflowInstance = AdUserHelper.CreateSkeletonWorkflowInstance(_dbContext);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            _dbContext.Dispose();
+        }
+
+        [Test]
+        public void Dbassessmentreviewdata_table_prevents_unknown_revieweraduser_due_to_FK()
+        {
+            _dbContext.DbAssessmentAssessData.Add(new DbAssessmentAssessData
+            {
+                ReviewerAdUserId = int.MaxValue,
+                WorkflowInstanceId = SkeletonWorkflowInstance.WorkflowInstanceId
+            });
+
+            var ex = Assert.Throws<DbUpdateException>(() => _dbContext.SaveChanges());
+            Assert.That(ex.InnerException.Message.Contains("The INSERT statement conflicted with the FOREIGN KEY constraint", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Test]
+        public void Dbassessmentreviewdata_table_prevents_unknown_assessoraduser_due_to_FK()
+        {
+            _dbContext.DbAssessmentAssessData.Add(new DbAssessmentAssessData
+            {
+                AssessorAdUserId = int.MaxValue,
+                WorkflowInstanceId = SkeletonWorkflowInstance.WorkflowInstanceId
+            });
+
+            var ex = Assert.Throws<DbUpdateException>(() => _dbContext.SaveChanges());
+            Assert.That(ex.InnerException.Message.Contains("The INSERT statement conflicted with the FOREIGN KEY constraint", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Test]
+        public void Dbassessmentreviewdata_table_prevents_unknown_verifieraduser_due_to_FK()
+        {
+            _dbContext.DbAssessmentAssessData.Add(new DbAssessmentAssessData
+            {
+                VerifierAdUserId = int.MaxValue,
+                WorkflowInstanceId = SkeletonWorkflowInstance.WorkflowInstanceId
+            });
+
+            var ex = Assert.Throws<DbUpdateException>(() => _dbContext.SaveChanges());
+            Assert.That(ex.InnerException.Message.Contains("The INSERT statement conflicted with the FOREIGN KEY constraint", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}
+

--- a/src/Databases/WorkflowDatabase.Tests/AdUserTests/DbAssessmentAssignTaskTests.cs
+++ b/src/Databases/WorkflowDatabase.Tests/AdUserTests/DbAssessmentAssignTaskTests.cs
@@ -1,0 +1,65 @@
+using System;
+using Common.Helpers;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using WorkflowDatabase.EF;
+using WorkflowDatabase.EF.Models;
+using WorkflowDatabase.Tests.Helpers;
+
+namespace WorkflowDatabase.Tests.AdUserTests
+{
+    public class DbAssessmentAssignTaskTests
+    {
+        private WorkflowDbContext _dbContext;
+        private AdUser TestUser1 { get; set; }
+        private AdUser TestUser2 { get; set; }
+        private WorkflowInstance SkeletonWorkflowInstance { get; set; }
+
+        [SetUp]
+        public void Setup()
+        {
+            _dbContext = TestSetupHelper.CreateWorkflowDbContext();
+            DatabasesHelpers.ClearWorkflowDbTables(_dbContext);
+
+            TestUser1 = AdUserHelper.CreateTestUser(_dbContext);
+            TestUser2 = AdUserHelper.CreateTestUser(_dbContext, 2);
+
+            SkeletonWorkflowInstance = AdUserHelper.CreateSkeletonWorkflowInstance(_dbContext);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            _dbContext.Dispose();
+        }
+
+        [Test]
+        public void Dbassessmentassigntask_table_prevents_unknown_assessoraduser_due_to_FK()
+        {
+            _dbContext.DbAssessmentAssignTask.Add(new DbAssessmentAssignTask
+            {
+                ProcessId = SkeletonWorkflowInstance.ProcessId,
+                Status = string.Empty,
+                AssessorAdUserId = 3
+            });
+
+            var ex = Assert.Throws<DbUpdateException>(() => _dbContext.SaveChanges());
+            Assert.That(ex.InnerException.Message.Contains("The INSERT statement conflicted with the FOREIGN KEY constraint", StringComparison.OrdinalIgnoreCase));
+        }
+        [Test]
+        public void Dbassessmentassigntask_table_prevents_unknown_verifieraduser_due_to_FK()
+        {
+            _dbContext.DbAssessmentAssignTask.Add(new DbAssessmentAssignTask
+            {
+                ProcessId = SkeletonWorkflowInstance.ProcessId,
+                Status = string.Empty,
+                VerifierAdUserId = 3
+            });
+
+            var ex = Assert.Throws<DbUpdateException>(() => _dbContext.SaveChanges());
+            Assert.That(ex.InnerException.Message.Contains("The INSERT statement conflicted with the FOREIGN KEY constraint", StringComparison.OrdinalIgnoreCase));
+        }
+
+    }
+}
+

--- a/src/Databases/WorkflowDatabase.Tests/AdUserTests/DbAssessmentReviewTests.cs
+++ b/src/Databases/WorkflowDatabase.Tests/AdUserTests/DbAssessmentReviewTests.cs
@@ -1,0 +1,76 @@
+using System;
+using Common.Helpers;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using WorkflowDatabase.EF;
+using WorkflowDatabase.EF.Models;
+using WorkflowDatabase.Tests.Helpers;
+
+namespace WorkflowDatabase.Tests.AdUserTests
+{
+    public class DbAssessmentReviewTests
+    {
+        private WorkflowDbContext _dbContext;
+        private AdUser TestUser1 { get; set; }
+        private AdUser TestUser2 { get; set; }
+        private WorkflowInstance SkeletonWorkflowInstance { get; set; }
+
+        [SetUp]
+        public void Setup()
+        {
+            _dbContext = TestSetupHelper.CreateWorkflowDbContext();
+            DatabasesHelpers.ClearWorkflowDbTables(_dbContext);
+
+            TestUser1 = AdUserHelper.CreateTestUser(_dbContext);
+            TestUser2 = AdUserHelper.CreateTestUser(_dbContext, 2);
+
+            SkeletonWorkflowInstance = AdUserHelper.CreateSkeletonWorkflowInstance(_dbContext);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            _dbContext.Dispose();
+        }
+
+        [Test]
+        public void Dbassessmentreviewdata_table_prevents_unknown_revieweraduser_due_to_FK()
+        {
+            _dbContext.DbAssessmentReviewData.Add(new DbAssessmentReviewData
+            {
+                ReviewerAdUserId = int.MaxValue,
+                WorkflowInstanceId = SkeletonWorkflowInstance.WorkflowInstanceId
+            });
+
+            var ex = Assert.Throws<DbUpdateException>(() => _dbContext.SaveChanges());
+            Assert.That(ex.InnerException.Message.Contains("The INSERT statement conflicted with the FOREIGN KEY constraint", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Test]
+        public void Dbassessmentreviewdata_table_prevents_unknown_assessoraduser_due_to_FK()
+        {
+            _dbContext.DbAssessmentReviewData.Add(new DbAssessmentReviewData
+            {
+                AssessorAdUserId = int.MaxValue,
+                WorkflowInstanceId = SkeletonWorkflowInstance.WorkflowInstanceId
+            });
+
+            var ex = Assert.Throws<DbUpdateException>(() => _dbContext.SaveChanges());
+            Assert.That(ex.InnerException.Message.Contains("The INSERT statement conflicted with the FOREIGN KEY constraint", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Test]
+        public void Dbassessmentreviewdata_table_prevents_unknown_verifieraduser_due_to_FK()
+        {
+            _dbContext.DbAssessmentReviewData.Add(new DbAssessmentReviewData
+            {
+                VerifierAdUserId = int.MaxValue,
+                WorkflowInstanceId = SkeletonWorkflowInstance.WorkflowInstanceId
+            });
+
+            var ex = Assert.Throws<DbUpdateException>(() => _dbContext.SaveChanges());
+            Assert.That(ex.InnerException.Message.Contains("The INSERT statement conflicted with the FOREIGN KEY constraint", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}
+

--- a/src/Databases/WorkflowDatabase.Tests/AdUserTests/DbAssessmentVerifyTests.cs
+++ b/src/Databases/WorkflowDatabase.Tests/AdUserTests/DbAssessmentVerifyTests.cs
@@ -1,0 +1,76 @@
+using System;
+using Common.Helpers;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using WorkflowDatabase.EF;
+using WorkflowDatabase.EF.Models;
+using WorkflowDatabase.Tests.Helpers;
+
+namespace WorkflowDatabase.Tests.AdUserTests
+{
+    public class DbAssessmentVerifyTests
+    {
+        private WorkflowDbContext _dbContext;
+        private AdUser TestUser1 { get; set; }
+        private AdUser TestUser2 { get; set; }
+        private WorkflowInstance SkeletonWorkflowInstance { get; set; }
+
+        [SetUp]
+        public void Setup()
+        {
+            _dbContext = TestSetupHelper.CreateWorkflowDbContext();
+            DatabasesHelpers.ClearWorkflowDbTables(_dbContext);
+
+            TestUser1 = AdUserHelper.CreateTestUser(_dbContext);
+            TestUser2 = AdUserHelper.CreateTestUser(_dbContext, 2);
+
+            SkeletonWorkflowInstance = AdUserHelper.CreateSkeletonWorkflowInstance(_dbContext);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            _dbContext.Dispose();
+        }
+
+        [Test]
+        public void Dbassessmentverifydata_table_prevents_unknown_revieweraduser_due_to_FK()
+        {
+            _dbContext.DbAssessmentVerifyData.Add(new DbAssessmentVerifyData
+            {
+                ReviewerAdUserId = int.MaxValue,
+                WorkflowInstanceId = SkeletonWorkflowInstance.WorkflowInstanceId
+            });
+
+            var ex = Assert.Throws<DbUpdateException>(() => _dbContext.SaveChanges());
+            Assert.That(ex.InnerException.Message.Contains("The INSERT statement conflicted with the FOREIGN KEY constraint", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Test]
+        public void Dbassessmentverifydata_table_prevents_unknown_assessoraduser_due_to_FK()
+        {
+            _dbContext.DbAssessmentVerifyData.Add(new DbAssessmentVerifyData
+            {
+                AssessorAdUserId = int.MaxValue,
+                WorkflowInstanceId = SkeletonWorkflowInstance.WorkflowInstanceId
+            });
+
+            var ex = Assert.Throws<DbUpdateException>(() => _dbContext.SaveChanges());
+            Assert.That(ex.InnerException.Message.Contains("The INSERT statement conflicted with the FOREIGN KEY constraint", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Test]
+        public void Dbassessmentverifydata_table_prevents_unknown_verifieraduser_due_to_FK()
+        {
+            _dbContext.DbAssessmentVerifyData.Add(new DbAssessmentVerifyData
+            {
+                VerifierAdUserId = int.MaxValue,
+                WorkflowInstanceId = SkeletonWorkflowInstance.WorkflowInstanceId
+            });
+
+            var ex = Assert.Throws<DbUpdateException>(() => _dbContext.SaveChanges());
+            Assert.That(ex.InnerException.Message.Contains("The INSERT statement conflicted with the FOREIGN KEY constraint", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}
+

--- a/src/Databases/WorkflowDatabase.Tests/AdUserTests/HpdUserTests.cs
+++ b/src/Databases/WorkflowDatabase.Tests/AdUserTests/HpdUserTests.cs
@@ -1,0 +1,50 @@
+using System;
+using Common.Helpers;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using WorkflowDatabase.EF;
+using WorkflowDatabase.EF.Models;
+using WorkflowDatabase.Tests.Helpers;
+
+namespace WorkflowDatabase.Tests.AdUserTests
+{
+    public class HpdUserTests
+    {
+        private WorkflowDbContext _dbContext;
+        private AdUser TestUser1 { get; set; }
+        private AdUser TestUser2 { get; set; }
+        private WorkflowInstance SkeletonWorkflowInstance { get; set; }
+
+        [SetUp]
+        public void Setup()
+        {
+            _dbContext = TestSetupHelper.CreateWorkflowDbContext();
+            DatabasesHelpers.ClearWorkflowDbTables(_dbContext);
+
+            TestUser1 = AdUserHelper.CreateTestUser(_dbContext);
+            TestUser2 = AdUserHelper.CreateTestUser(_dbContext, 2);
+
+            SkeletonWorkflowInstance = AdUserHelper.CreateSkeletonWorkflowInstance(_dbContext);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            _dbContext.Dispose();
+        }
+
+        [Test]
+        public void Hpduser_table_prevents_unknown_AdUser_due_to_FK()
+        {
+            _dbContext.HpdUser.Add(new HpdUser
+            {
+                HpdUsername = string.Empty,
+                AdUserId = 3
+            });
+
+            var ex = Assert.Throws<DbUpdateException>(() => _dbContext.SaveChanges());
+            Assert.That(ex.InnerException.Message.Contains("The INSERT statement conflicted with the FOREIGN KEY constraint", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}
+

--- a/src/Databases/WorkflowDatabase.Tests/AdUserTests/OnHoldTests.cs
+++ b/src/Databases/WorkflowDatabase.Tests/AdUserTests/OnHoldTests.cs
@@ -1,0 +1,68 @@
+using System;
+using Common.Helpers;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using WorkflowDatabase.EF;
+using WorkflowDatabase.EF.Models;
+using WorkflowDatabase.Tests.Helpers;
+
+namespace WorkflowDatabase.Tests.AdUserTests
+{
+    public class OnHoldTests
+    {
+        private WorkflowDbContext _dbContext;
+        private AdUser TestUser1 { get; set; }
+        private AdUser TestUser2 { get; set; }
+        private WorkflowInstance SkeletonWorkflowInstance { get; set; }
+
+        [SetUp]
+        public void Setup()
+        {
+            _dbContext = TestSetupHelper.CreateWorkflowDbContext();
+            DatabasesHelpers.ClearWorkflowDbTables(_dbContext);
+
+            TestUser1 = AdUserHelper.CreateTestUser(_dbContext);
+            TestUser2 = AdUserHelper.CreateTestUser(_dbContext, 2);
+
+            SkeletonWorkflowInstance = AdUserHelper.CreateSkeletonWorkflowInstance(_dbContext);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            _dbContext.Dispose();
+        }
+
+        [Test]
+        public void OnHold_table_prevents_unknown_OffHoldByAdUser_due_to_FK()
+        {
+            _dbContext.OnHold.Add(new OnHold
+            {
+                WorkflowInstanceId = SkeletonWorkflowInstance.WorkflowInstanceId,
+                ProcessId = SkeletonWorkflowInstance.ProcessId,
+                OnHoldTime = DateTime.Now,
+                OnHoldByAdUserId = 1,
+                OffHoldByAdUserId = 3
+            });
+
+            var ex = Assert.Throws<DbUpdateException>(() => _dbContext.SaveChanges());
+            Assert.That(ex.InnerException.Message.Contains("The INSERT statement conflicted with the FOREIGN KEY constraint", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Test]
+        public void OnHold_table_prevents_unknown_OnHoldByAdUser_due_to_FK()
+        {
+            _dbContext.OnHold.Add(new OnHold
+            {
+                WorkflowInstanceId = SkeletonWorkflowInstance.WorkflowInstanceId,
+                ProcessId = SkeletonWorkflowInstance.ProcessId,
+                OnHoldTime = DateTime.Now,
+                OnHoldByAdUserId = 3
+            });
+
+            var ex = Assert.Throws<DbUpdateException>(() => _dbContext.SaveChanges());
+            Assert.That(ex.InnerException.Message.Contains("The INSERT statement conflicted with the FOREIGN KEY constraint", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}
+

--- a/src/Databases/WorkflowDatabase.Tests/AdUserTests/TaskNoteTests.cs
+++ b/src/Databases/WorkflowDatabase.Tests/AdUserTests/TaskNoteTests.cs
@@ -1,0 +1,73 @@
+using System;
+using Common.Helpers;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using WorkflowDatabase.EF;
+using WorkflowDatabase.EF.Models;
+using WorkflowDatabase.Tests.Helpers;
+
+namespace WorkflowDatabase.Tests.AdUserTests
+{
+    public class TaskNoteTests
+    {
+        private WorkflowDbContext _dbContext;
+        private AdUser TestUser1 { get; set; }
+        private AdUser TestUser2 { get; set; }
+        private WorkflowInstance SkeletonWorkflowInstance { get; set; }
+
+        [SetUp]
+        public void Setup()
+        {
+            _dbContext = TestSetupHelper.CreateWorkflowDbContext();
+            DatabasesHelpers.ClearWorkflowDbTables(_dbContext);
+
+            TestUser1 = AdUserHelper.CreateTestUser(_dbContext);
+            TestUser2 = AdUserHelper.CreateTestUser(_dbContext, 2);
+
+            SkeletonWorkflowInstance = AdUserHelper.CreateSkeletonWorkflowInstance(_dbContext);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            _dbContext.Dispose();
+        }
+
+        [Test]
+        public void TaskNote_table_prevents_unknown_LastModifiedByAdUserId_due_to_FK()
+        {
+            _dbContext.TaskNote.Add(new TaskNote
+            {
+                WorkflowInstanceId = SkeletonWorkflowInstance.WorkflowInstanceId,
+                ProcessId = SkeletonWorkflowInstance.ProcessId,
+                Created = DateTime.Now,
+                LastModified = DateTime.Now,
+                Text = string.Empty,
+                CreatedByAdUserId = 1,
+                LastModifiedByAdUserId = 3
+            });
+
+            var ex = Assert.Throws<DbUpdateException>(() => _dbContext.SaveChanges());
+            Assert.That(ex.InnerException.Message.Contains("The INSERT statement conflicted with the FOREIGN KEY constraint", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Test]
+        public void TaskNote_table_prevents_unknown_CreatedByAdUserId_due_to_FK()
+        {
+            _dbContext.TaskNote.Add(new TaskNote
+            {
+                WorkflowInstanceId = SkeletonWorkflowInstance.WorkflowInstanceId,
+                ProcessId = SkeletonWorkflowInstance.ProcessId,
+                Created = DateTime.Now,
+                LastModified = DateTime.Now,
+                Text = string.Empty,
+                CreatedByAdUserId = 3,
+                LastModifiedByAdUserId = 1
+            });
+
+            var ex = Assert.Throws<DbUpdateException>(() => _dbContext.SaveChanges());
+            Assert.That(ex.InnerException.Message.Contains("The INSERT statement conflicted with the FOREIGN KEY constraint", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}
+

--- a/src/Databases/WorkflowDatabase.Tests/DatabaseIntegrityTests.cs
+++ b/src/Databases/WorkflowDatabase.Tests/DatabaseIntegrityTests.cs
@@ -4,9 +4,9 @@ using System.Threading.Tasks;
 using Common.Helpers;
 using Microsoft.EntityFrameworkCore;
 using NUnit.Framework;
-using Portal.UnitTests.Helpers;
 using WorkflowDatabase.EF;
 using WorkflowDatabase.EF.Models;
+using WorkflowDatabase.Tests.Helpers;
 
 namespace WorkflowDatabase.Tests
 {

--- a/src/Databases/WorkflowDatabase.Tests/Helpers/AdUserHelper.cs
+++ b/src/Databases/WorkflowDatabase.Tests/Helpers/AdUserHelper.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using WorkflowDatabase.EF;
 using WorkflowDatabase.EF.Models;
 
-namespace Portal.UnitTests.Helpers
+namespace WorkflowDatabase.Tests.Helpers
 {
     internal static class AdUserHelper
     {
@@ -33,6 +33,29 @@ namespace Portal.UnitTests.Helpers
             dbContext.SaveChanges();
 
             return user;
+        }
+
+        internal static WorkflowInstance CreateSkeletonWorkflowInstance(WorkflowDbContext dbContext, int processId = 1)
+        {
+            var workflowInstanceList = dbContext.WorkflowInstance.ToList();
+            var workflowInstance = workflowInstanceList.SingleOrDefault(u =>
+                u.ProcessId == processId);
+            if (workflowInstance != null) return workflowInstance;
+
+            workflowInstance = new WorkflowInstance
+            {
+                ProcessId = processId,
+                PrimarySdocId = 1,
+                SerialNumber = string.Empty,
+                ActivityName = string.Empty,
+                ActivityChangedAt = DateTime.Now,
+                StartedAt = DateTime.Now,
+                Status = string.Empty
+            };
+            dbContext.WorkflowInstance.Add(workflowInstance);
+            dbContext.SaveChanges();
+
+            return workflowInstance;
         }
     }
 }

--- a/src/Databases/WorkflowDatabase.Tests/Helpers/TestSetupHelper.cs
+++ b/src/Databases/WorkflowDatabase.Tests/Helpers/TestSetupHelper.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.EntityFrameworkCore;
+using WorkflowDatabase.EF;
+
+namespace WorkflowDatabase.Tests.Helpers
+{
+    internal static class TestSetupHelper
+    {
+        internal static WorkflowDbContext CreateWorkflowDbContext()
+        {
+            var dbContextOptions = new DbContextOptionsBuilder<WorkflowDbContext>()
+               .UseSqlServer(
+                   @"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=taskmanager-dev-workflowdatabase;Integrated Security=True;Persist Security Info=False;Pooling=False;MultipleActiveResultSets=False;Connect Timeout=60;Encrypt=False;TrustServerCertificate=False")
+               .Options;
+
+            return new WorkflowDbContext(dbContextOptions);
+        }
+    }
+}


### PR DESCRIPTION
The Db integrity tests over the new FK relationships for AdUsers.

Note refactor of setup etc. Inspired by noticing some of the older ones aren't testing what we think they are but fixing those out of scope of an already bloated story.