### PR TITLE
Features/validate pcpwebcert sdocsvc

### DIFF
--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Program.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Program.cs
@@ -81,6 +81,7 @@ namespace SourceDocumentCoordinator
                 services.AddHttpClient<ISourceDocumentServiceApiClient, SourceDocumentServiceApiClient>()
                     .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
                     {
+                        ServerCertificateCustomValidationCallback = (message, certificate2, arg3, arg4) => true,
                         Credentials = new NetworkCredential
                         {
                             UserName = startupSecretsConfig.SourceDocumentServiceUsername,

--- a/src/SourceDocumentService/App.config
+++ b/src/SourceDocumentService/App.config
@@ -2,6 +2,7 @@
 <configuration>
 
   <appSettings>
+    <add key="PermittedRoles" value="roleHere"/>
     <add key="FilestorePath" value="pathHere"/>
     <add key="ContentServiceBaseUrl" value="urlHere"/>
     <add key="ContentServiceUsername" value="username"/>

--- a/src/SourceDocumentService/App.config.token
+++ b/src/SourceDocumentService/App.config.token
@@ -2,6 +2,7 @@
 <configuration>
 
   <appSettings>
+    <add key="PermittedRoles" value="__PermittedRoles__"/>
     <add key="FilestorePath" value="__FileStorePath__"/>
     <add key="ContentServiceBaseUrl" value="__ContentServiceUrl__"/>
     <add key="ContentServiceUsername" value="__ContentServiceUsername__"/>

--- a/src/SourceDocumentService/Controllers/SourceDocumentController.cs
+++ b/src/SourceDocumentService/Controllers/SourceDocumentController.cs
@@ -7,11 +7,13 @@ using System.ComponentModel.DataAnnotations;
 using SourceDocumentService.HttpClients;
 using System.IO;
 using System.Security;
+using Microsoft.AspNetCore.Authorization;
 using SourceDocumentService.Configuration;
 
 namespace SourceDocumentService.Controllers
 {
     [ApiController]
+    [Authorize(Policy = "ADRoleOnly")]
     public class SourceDocumentController : ControllerBase
     {
         private readonly ILogger<SourceDocumentController> _logger;
@@ -35,7 +37,7 @@ namespace SourceDocumentService.Controllers
         /// <param name="sdocId"></param>
         /// <param name="filename"></param>
         /// <returns></returns>
-        [Route("/v1/PostSourceDocument/{processId}/{sdocId}/{filename}")]
+        [Route("/SourceDocumentService/v1/PostSourceDocument/{processId}/{sdocId}/{filename}")]
         [HttpPost]
         public async Task<IActionResult> PostSourceDocumentToContentService([FromRoute][Required] int processId, [FromRoute][Required] int sdocId, [Required][FromRoute] string filename)
         {

--- a/src/SourceDocumentService/Controllers/SourceDocumentController.cs
+++ b/src/SourceDocumentService/Controllers/SourceDocumentController.cs
@@ -38,7 +38,7 @@ namespace SourceDocumentService.Controllers
         /// <param name="sdocId"></param>
         /// <param name="filename"></param>
         /// <returns></returns>
-        [Route("/SourceDocumentService/v1/PostSourceDocument/{processId}/{sdocId}/{filename}")]
+        [Route("/v1/PostSourceDocument/{processId}/{sdocId}/{filename}")]
         [HttpPost]
         public async Task<IActionResult> PostSourceDocumentToContentService([FromRoute][Required] int processId, [FromRoute][Required] int sdocId, [Required][FromRoute] string filename)
         {

--- a/src/SourceDocumentService/Controllers/SourceDocumentController.cs
+++ b/src/SourceDocumentService/Controllers/SourceDocumentController.cs
@@ -4,12 +4,9 @@ using Microsoft.Extensions.Logging;
 using System.IO.Abstractions;
 using System.Threading.Tasks;
 using System.ComponentModel.DataAnnotations;
-using System.Configuration;
-using System.Net;
 using SourceDocumentService.HttpClients;
 using System.IO;
 using System.Security;
-using Serilog.Context;
 using SourceDocumentService.Configuration;
 
 namespace SourceDocumentService.Controllers

--- a/src/SourceDocumentService/Program.cs
+++ b/src/SourceDocumentService/Program.cs
@@ -1,8 +1,4 @@
-using System;
-using Common.Helpers;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Configuration.AzureKeyVault;
 using Microsoft.Extensions.Hosting;
 using Serilog;
 using Serilog.Events;

--- a/src/SourceDocumentService/Startup.cs
+++ b/src/SourceDocumentService/Startup.cs
@@ -35,8 +35,6 @@ namespace SourceDocumentService
                 options.AddPolicy("ADRoleOnly", policy => policy.RequireRole(ConfigurationManager.AppSettings["PermittedRoles"]));
             });
 
-            var s = ConfigurationManager.AppSettings["PermittedRoles"];
-
             services.AddMvc(config =>
             {
                 var policy = new AuthorizationPolicyBuilder()

--- a/src/SourceDocumentService/Startup.cs
+++ b/src/SourceDocumentService/Startup.cs
@@ -3,8 +3,10 @@ using System.Configuration;
 using System.IO.Abstractions;
 using System.Net;
 using System.Net.Http;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -27,6 +29,22 @@ namespace SourceDocumentService
         {
             services.AddControllers();
             services.AddHealthChecks();
+
+            services.AddAuthorization(options =>
+            {
+                options.AddPolicy("ADRoleOnly", policy => policy.RequireRole(ConfigurationManager.AppSettings["PermittedRoles"]));
+            });
+
+            var s = ConfigurationManager.AppSettings["PermittedRoles"];
+
+            services.AddMvc(config =>
+            {
+                var policy = new AuthorizationPolicyBuilder()
+                    .RequireAuthenticatedUser()
+                    .Build();
+
+                config.Filters.Add(new AuthorizeFilter(policy));
+            });
 
             services.AddScoped<IFileSystem, FileSystem>();
             services.AddScoped<IConfigurationManager, AppConfigConfigurationManager>();


### PR DESCRIPTION
- Validate client certificate as part of Source Document Service config
- Add AD group authorisation
- Remove unnecessary usings from SourceDocumentService