### PR TITLE
Bugfix Source Document Partial Error Display and Resilience

### DIFF
--- a/src/Portal/Portal.UnitTests/SourceDocumentDetailsTests.cs
+++ b/src/Portal/Portal.UnitTests/SourceDocumentDetailsTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Common.Factories;
 using Common.Factories.DocumentStatusFactory;
 using Common.Helpers;
 using Common.Messages.Events;
@@ -82,7 +81,7 @@ namespace Portal.UnitTests
 
             var ex = Assert.ThrowsAsync<InvalidOperationException>(() =>
                 sourceDocumentDetailsModel.OnGetAsync());
-            Assert.AreEqual("Unable to retrieve AssessmentData", ex.Data["OurMessage"]);
+            Assert.AreEqual($"Unable to retrieve AssessmentData for ProcessId 0", ex.Data["OurMessage"]);
         }
 
         [Test]

--- a/src/Portal/Portal/HttpClients/IDataServiceApiClient.cs
+++ b/src/Portal/Portal/HttpClients/IDataServiceApiClient.cs
@@ -1,10 +1,12 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
 using DataServices.Models;
 
 namespace Portal.HttpClients
 {
     public interface IDataServiceApiClient
     {
-        Task<DocumentAssessmentData> GetAssessmentData(int sdocId);
+        Task<(DocumentAssessmentData assessmentData, HttpStatusCode httpStatusCode, string errorMessage, Uri fullUri)> GetAssessmentData(int sdocId);
     }
 }

--- a/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml
+++ b/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml
@@ -214,8 +214,6 @@
                     </button>
                 </div>
             </div>
-            <div id="sourceDocumentsError"></div>
-
             <section class="dialog error collapse mt-3">
                 <h5>
                     <i class="fas fa-times-circle" style="font-size: 1.25rem;"></i>

--- a/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml.cs
@@ -230,10 +230,12 @@ namespace Portal.Pages.DbAssessment
 
             if (isWorkflowReadOnly)
             {
-                var appException = new ApplicationException($"Workflow Instance for {nameof(processId)} {processId} is readonly, cannot attach linked document");
-                _logger.LogError(appException,
-                    "Workflow Instance for ProcessId {ProcessId} is readonly, cannot attach linked document");
-                throw appException;
+                _logger.LogError("Workflow Instance for ProcessId {ProcessId} is readonly, cannot attach linked document");
+
+                return new JsonResult($"Workflow Instance for {nameof(processId)} {processId} is readonly, cannot attach linked document")
+                {
+                    StatusCode = (int)HttpStatusCode.InternalServerError
+                };
             }
 
             // first publish event
@@ -280,9 +282,9 @@ namespace Portal.Pages.DbAssessment
 
             if (isWorkflowReadOnly)
             {
-                _logger.LogError("Workflow Instance for ProcessId {ProcessId} is readonly, cannot attach linked document");
+                _logger.LogError("Workflow Instance for ProcessId {ProcessId} is readonly, cannot detach linked document");
 
-                return new JsonResult($"Workflow Instance for {nameof(processId)} {processId} is readonly, cannot attach linked document")
+                return new JsonResult($"Workflow Instance for {nameof(processId)} {processId} is readonly, cannot detach linked document")
                 {
                     StatusCode = (int)HttpStatusCode.InternalServerError
                 };

--- a/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml.cs
@@ -280,10 +280,12 @@ namespace Portal.Pages.DbAssessment
 
             if (isWorkflowReadOnly)
             {
-                var appException = new ApplicationException($"Workflow Instance for {nameof(processId)} {processId} is readonly, cannot attach linked document");
-                _logger.LogError(appException,
-                    "Workflow Instance for ProcessId {ProcessId} is readonly, cannot attach linked document");
-                throw appException;
+                _logger.LogError("Workflow Instance for ProcessId {ProcessId} is readonly, cannot attach linked document");
+
+                return new JsonResult($"Workflow Instance for {nameof(processId)} {processId} is readonly, cannot attach linked document")
+                {
+                    StatusCode = (int)HttpStatusCode.InternalServerError
+                };
             }
 
             _logger.LogInformation("Updating document status in database for _SourceDocumentDetailsModel with: ProcessId: {ProcessId}; LinkedSdocId: {LinkedSdocId}");

--- a/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml.cs
@@ -123,11 +123,10 @@ namespace Portal.Pages.DbAssessment
                     .AssessmentData
                     .FirstAsync(c => c.ProcessId == ProcessId);
             }
-            catch (InvalidOperationException e)
+            catch (Exception e)
             {
-                // Log and throw, as we're unable to get assessment data
-                e.Data.Add("OurMessage", "Unable to retrieve AssessmentData");
-                Console.WriteLine(e);
+                _logger.LogError(e, "Unable to retrieve AssessmentData for ProcessId {ProcessId}");
+
                 throw;
             }
         }

--- a/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml.cs
@@ -183,9 +183,9 @@ namespace Portal.Pages.DbAssessment
 
             try
             {
-                PrimaryDocumentStatus = await _dbContext.PrimaryDocumentStatus.FirstAsync(s => s.ProcessId == ProcessId);
+                PrimaryDocumentStatus = await _dbContext.PrimaryDocumentStatus.FirstOrDefaultAsync(s => s.ProcessId == ProcessId);
 
-                if (PrimaryDocumentStatus.ContentServiceId.HasValue)
+                if (PrimaryDocumentStatus?.ContentServiceId != null)
                     PrimaryDocumentStatus.ContentServiceUri =
                         _uriConfig.Value.BuildContentServiceUri(PrimaryDocumentStatus.ContentServiceId.Value);
             }

--- a/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml.cs
@@ -408,10 +408,12 @@ namespace Portal.Pages.DbAssessment
 
             if (isWorkflowReadOnly)
             {
-                var appException = new ApplicationException($"Workflow Instance for {nameof(processId)} {processId} is readonly, cannot attach linked document");
-                _logger.LogError(appException,
-                    "Workflow Instance for ProcessId {ProcessId} is readonly, cannot attach linked document");
-                throw appException;
+                _logger.LogError("Workflow Instance for ProcessId {ProcessId} is readonly, cannot detach database document");
+
+                return new JsonResult($"Workflow Instance for {nameof(processId)} {processId} is readonly, cannot detach database document")
+                {
+                    StatusCode = (int)HttpStatusCode.InternalServerError
+                };
             }
 
             _logger.LogInformation("Updating document status in database for _SourceDocumentDetailsModel with: ProcessId: {ProcessId}; SdocId: {SdocId}");

--- a/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml.cs
@@ -126,7 +126,7 @@ namespace Portal.Pages.DbAssessment
             catch (Exception e)
             {
                 _logger.LogError(e, "Unable to retrieve AssessmentData for ProcessId {ProcessId}");
-
+                e.Data.Add("OurMessage", $"Unable to retrieve AssessmentData for ProcessId {ProcessId}");
                 throw;
             }
         }

--- a/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml.cs
+++ b/src/Portal/Portal/Pages/DbAssessment/_SourceDocumentDetails.cshtml.cs
@@ -143,11 +143,10 @@ namespace Portal.Pages.DbAssessment
                     .Where(c => c.ProcessId == ProcessId)
                     .ToListAsync();
             }
-            catch (ArgumentNullException e)
+            catch (Exception e)
             {
-                // Log and throw, as we're unable to get Linked Documents
-                e.Data.Add("OurMessage", "Unable to retrieve Linked Documents");
-                Console.WriteLine(e);
+                _logger.LogError(e, "Unable to retrieve Linked Documents for ProcessId {ProcessId}");
+
                 throw;
             }
         }
@@ -171,11 +170,10 @@ namespace Portal.Pages.DbAssessment
                 }
 
             }
-            catch (ArgumentNullException e)
+            catch (Exception e)
             {
-                // Log and throw, as we're unable to get Database Documents
-                e.Data.Add("OurMessage", "Unable to retrieve Database Documents");
-                Console.WriteLine(e);
+                _logger.LogError(e, "Unable to retrieve Database Documents for ProcessId {ProcessId}");
+
                 throw;
             }
         }
@@ -192,11 +190,11 @@ namespace Portal.Pages.DbAssessment
                     PrimaryDocumentStatus.ContentServiceUri =
                         _uriConfig.Value.BuildContentServiceUri(PrimaryDocumentStatus.ContentServiceId.Value);
             }
-            catch (InvalidOperationException e)
+            catch (Exception e)
             {
-                // Log that we're unable to get a Source Doc Status row
-                e.Data.Add("OurMessage", "Unable to retrieve PrimaryDocumentStatus");
-                Console.WriteLine(e);
+                _logger.LogError(e, "Unable to retrieve PrimaryDocumentStatus for ProcessId {ProcessId}");
+
+                throw;
             }
         }
 

--- a/src/Portal/Portal/wwwroot/js/_SourceDocumentDetails.js
+++ b/src/Portal/Portal/wwwroot/js/_SourceDocumentDetails.js
@@ -195,10 +195,10 @@
                 $("#addDatabaseSourceDocument .dialog.warning").collapse("hide");
                 $("#addSourceErrorMessage").text("");
             },
-            error: function () {
+            error: function (error) {
                 $("#addDatabaseSourceDocument .dialog.success").collapse("hide");
                 $("#addDatabaseSourceDocument .dialog.warning").collapse("hide");
-                $("#addSourceErrorMessage").text("Failed to connect to SDRA. Please try again later.");
+                $("#addSourceErrorMessage").text(JSON.parse(error.responseText));
                 $("#addDatabaseSourceDocument .dialog.error").collapse("show");
             }
         });

--- a/src/Portal/Portal/wwwroot/js/_SourceDocumentDetails.js
+++ b/src/Portal/Portal/wwwroot/js/_SourceDocumentDetails.js
@@ -1,6 +1,7 @@
 ﻿$(document).ready(function () {
     var processId = Number($("#hdnProcessId").val());
     var isReadOnly = $("#IsReadOnly").val() === "True";
+    var errorMessageDelayCollapse = 2500; //2.5 seconds
 
     getSourceDocuments();
 
@@ -68,12 +69,17 @@
                     getSourceDocuments();
                 },
                 error: function (error) {
-                    //TODO: Implement error dialogs
-                    $("#assignTasksError")
-                        .html("<div class=\"alert alert-danger\" role=\"alert\">Failed to create new assign task section.</div>");
+                    $("#addDatabaseSourceDocument .dialog.success").collapse("hide");
+                    $("#addDatabaseSourceDocument .dialog.warning").collapse("hide");
+                    $("#addSourceErrorMessage").text(JSON.parse(error.responseText));
+                    $("#addDatabaseSourceDocument .dialog.error").collapse("show");
 
                     $(parent).show();
                     $(parent).siblings(".attachLinkedDocumentSpinnerContainer").hide();
+
+                    setTimeout(function() {
+                        $("#addDatabaseSourceDocument .dialog.error").collapse('hide');
+                    },errorMessageDelayCollapse);
                 }
             });
         });
@@ -102,12 +108,18 @@
                     getSourceDocuments();
                 },
                 error: function (error) {
-                    //TODO: Implement error dialogs
-                    $("#assignTasksError")
-                        .html("<div class=\"alert alert-danger\" role=\"alert\">Failed to create new assign task section.</div>");
+                    $("#addDatabaseSourceDocument .dialog.success").collapse("hide");
+                    $("#addDatabaseSourceDocument .dialog.warning").collapse("hide");
+                    $("#addSourceErrorMessage").text(JSON.parse(error.responseText));
+                    $("#addDatabaseSourceDocument .dialog.error").collapse("show");
 
                     $(parent).show();
                     $(parent).siblings(".detachLinkedDocumentSpinnerContainer").hide();
+
+                    setTimeout(function() {
+                        $("#addDatabaseSourceDocument .dialog.error").collapse('hide');
+                    },errorMessageDelayCollapse);
+
                 }
             });
         });
@@ -136,12 +148,17 @@
                     getSourceDocuments();
                 },
                 error: function (error) {
-                    //TODO: Implement error dialogs
-                    $("#assignTasksError")
-                        .html("<div class=\"alert alert-danger\" role=\"alert\">Failed to create new assign task section.</div>");
+                    $("#addDatabaseSourceDocument .dialog.success").collapse("hide");
+                    $("#addDatabaseSourceDocument .dialog.warning").collapse("hide");
+                    $("#addSourceErrorMessage").text(JSON.parse(error.responseText));
+                    $("#addDatabaseSourceDocument .dialog.error").collapse("show");
 
                     $(parent).show();
                     $(parent).siblings(".detachDatabaseDocumentSpinnerContainer").hide();
+
+                    setTimeout(function() {
+                        $("#addDatabaseSourceDocument .dialog.error").collapse('hide');
+                    },errorMessageDelayCollapse);
                 }
             });
         });


### PR DESCRIPTION
## Pass actual errors from Data Service to Portal UI

Data Service already returns a range of specific error messages so rewrote the client in Portal to pass these through to caller. These come off the back of searching and adding e.g. searching for a sdocId that does not exist.

I wrapped calls to the data service client to continue catching unexpected exceptions and now return a `JsonResult` 

These wrapped calls will now return a `JsonResult`  with the Data Service error back to the UI.

UI will display these errors in the existing source doc partial error dialogue. 

## Add logging to 'get' functions

The functions following functions now log errors that occur but continue to re-throw to maintain the pink coloured warning box we have in place of the sdoc partial when it fails to load.
- `GetAssessmentDataAsync()`
- `GetPrimaryDocumentStatusAsync()`
- `GetLinkedDocumentsAsync()`
- `GetDatabaseDocumentsAsync()`

## Attach and detach buttons

Now return errors back to the UI that occur when clicking on the icons in source document rows for:

- Attaching linked document
- Detaching linked document
- Detaching database document

These errors will appear in the same collapsible dialogue that appears under the sdoc search box. The difference is, I have set it to collapse again after 2.5 seconds (easy to change). We don't have the same sort of behaviour to rely on that we do with the search box and adding to remove it on further interaction.

