### PR TITLE
Use a unique identifier per endpoint for heartbeats

### DIFF
--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Config/NsbConfig.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Config/NsbConfig.cs
@@ -11,5 +11,6 @@ namespace SourceDocumentCoordinator.Config
         public string LocalDbServer { get; set; }
         public Uri AzureDbTokenUrl { get; set; }
         public string ServiceControlQueue { get; set; }
+        public Guid SourceDocumentCoordinatorUniqueIdentifier { get; set; }
     }
 }

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Program.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Program.cs
@@ -141,6 +141,9 @@ namespace SourceDocumentCoordinator
                         nsbConfig.ServiceControlQueue,
                         TimeSpan.FromSeconds(15),
                         TimeSpan.FromSeconds(30));
+
+                    endpointConfiguration.UniquelyIdentifyRunningInstance()
+                        .UsingCustomIdentifier(nsbConfig.SourceDocumentCoordinatorUniqueIdentifier);
                 }
 
                 var serilogTracing = endpointConfiguration.EnableSerilogTracing(Log.Logger);

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Config/NsbConfig.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Config/NsbConfig.cs
@@ -11,5 +11,6 @@ namespace WorkflowCoordinator.Config
         public string LocalDbServer { get; set; }
         public Uri AzureDbTokenUrl { get; set; }
         public string ServiceControlQueue { get; set; }
+        public Guid WorkflowCoordinatorUniqueIdentifier { get; set; }
     }
 }

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Program.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Program.cs
@@ -150,6 +150,9 @@ namespace WorkflowCoordinator
                             nsbConfig.ServiceControlQueue,
                             TimeSpan.FromSeconds(15),
                             TimeSpan.FromSeconds(30));
+
+                        endpointConfiguration.UniquelyIdentifyRunningInstance()
+                            .UsingCustomIdentifier(nsbConfig.WorkflowCoordinatorUniqueIdentifier);
                     }
 
 


### PR DESCRIPTION
- Use a unique identifier for NSB heartbeats as they could respawn across different Azure worker roles