### PR TITLE
NCNE : fixing error in creation of stages

### DIFF
--- a/src/NCNEPortal/Helpers/PageValidationHelper.cs
+++ b/src/NCNEPortal/Helpers/PageValidationHelper.cs
@@ -162,7 +162,7 @@ namespace NCNEPortal.Helpers
             {
                 if (actualReturnDate3Ps == null)
                 {
-                    validationErrorMessages.Add("3PS : return date must be completed first");
+                    validationErrorMessages.Add("3PS : Please enter the actual return date before publishing the chart");
                     isValid = false;
                 }
 

--- a/src/NCNEPortal/Pages/NewTask.cshtml.cs
+++ b/src/NCNEPortal/Pages/NewTask.cshtml.cs
@@ -259,10 +259,10 @@ namespace NCNEPortal
                     NcneTaskStageType.Specification => (this.ChartType == NcneChartType.Adoption.ToString()
                                ? NcneTaskStageStatus.Open.ToString() :
                                NcneTaskStageStatus.InProgress.ToString()),
-                    NcneTaskStageType.V2 => (this.Verifier2 == null
+                    NcneTaskStageType.V2 => (role.VerifierTwo == null
                         ? NcneTaskStageStatus.Inactive.ToString()
                         : NcneTaskStageStatus.Open.ToString()),
-                    NcneTaskStageType.V2_Rework => (this.Verifier2 == null
+                    NcneTaskStageType.V2_Rework => (role.VerifierTwo == null
                         ? NcneTaskStageStatus.Inactive.ToString()
                         : NcneTaskStageStatus.Open.ToString()),
                     NcneTaskStageType.Forms => NcneTaskStageStatus.InProgress.ToString(),


### PR DESCRIPTION
After the Aduser changes, V2 stages are created even without V2 user.
Fixing the issue by using getting Aduser object rather than using the field in the page.