### PR TITLE
Features/linkeddocs use uniqueid when updating csp guid

### DIFF
--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator.UnitTests/PersistDocumentInStoreCommandHandlerTests.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator.UnitTests/PersistDocumentInStoreCommandHandlerTests.cs
@@ -14,6 +14,7 @@ using SourceDocumentCoordinator.Handlers;
 using SourceDocumentCoordinator.HttpClients;
 using SourceDocumentCoordinator.Messages;
 using WorkflowDatabase.EF;
+using WorkflowDatabase.EF.Models;
 
 namespace SourceDocumentCoordinator.UnitTests
 {
@@ -81,6 +82,20 @@ namespace SourceDocumentCoordinator.UnitTests
         [Test]
         public async Task Test_When_Linked_Document_Successfully_posted_to_SourceDocumentService_Then_Document_Status_and_FileLocation_is_Updated()
         {
+            var linkedDocUniqueId = Guid.NewGuid();
+
+            _dbContext.LinkedDocument.Add(new LinkedDocument
+            {
+                ProcessId = 5678,
+                LinkType = "Forward",
+                Created = DateTime.Now.Date,
+                UniqueId = linkedDocUniqueId,
+                LinkedSdocId = 1999999,
+                Status = "Started"
+            });
+
+            await _dbContext.SaveChangesAsync();
+
             //Given
             var message = new PersistDocumentInStoreCommand()
             {
@@ -88,7 +103,8 @@ namespace SourceDocumentCoordinator.UnitTests
                 ProcessId = 5678,
                 SourceDocumentId = 1999999,
                 SourceType = SourceType.Linked,
-                Filepath = @"c:\test\TestImage.tif"
+                Filepath = @"c:\test\TestImage.tif",
+                UniqueId = linkedDocUniqueId
             };
 
             A.CallTo(() =>

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Handlers/PersistDocumentInStoreCommandHandler.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Handlers/PersistDocumentInStoreCommandHandler.cs
@@ -59,7 +59,7 @@ namespace SourceDocumentCoordinator.Handlers
             _logger.LogInformation("Successfully called SourceDocumentService to post document to Content Service with Content Service Id {ContentServiceId}");
 
             await UpdatePrimaryDocumentStatus(message, contentServiceId);
-            await UpdateLinkedDocuments(message, contentServiceId);
+            await UpdateLinkedDocument(message, contentServiceId, message.UniqueId);
             await UpdateDatabaseDocuments(message, contentServiceId);
 
             await _dbContext.SaveChangesAsync();
@@ -88,24 +88,20 @@ namespace SourceDocumentCoordinator.Handlers
             }
         }
 
-        private async Task UpdateLinkedDocuments(PersistDocumentInStoreCommand message, Guid newGuid)
+        private async Task UpdateLinkedDocument(PersistDocumentInStoreCommand message, Guid newGuid, Guid uniqueId)
         {
 
             _logger.LogInformation("Updating LinkedDocument with generated source document file info");
 
-            var linkedDocuments = await _dbContext.LinkedDocument
-                                                                .Where(pd => pd.LinkedSdocId == message.SourceDocumentId
+            var linkedDocument = await _dbContext.LinkedDocument
+                                                                .Where(pd => pd.UniqueId == uniqueId
                                                                              && (pd.Status == SourceDocumentRetrievalStatus.Started.ToString()
                                                                                  || pd.Status == SourceDocumentRetrievalStatus.Ready.ToString()))
-                                                                .ToListAsync();
-
-            foreach (var linkedDocument in linkedDocuments)
-            {
-                linkedDocument.ContentServiceId = newGuid;
-                linkedDocument.Filename = Path.GetFileName(message.Filepath)?.Trim();
-                linkedDocument.Filepath = Path.GetDirectoryName(message.Filepath)?.Trim();
-                linkedDocument.Status = SourceDocumentRetrievalStatus.FileGenerated.ToString();
-            }
+                                                                .SingleOrDefaultAsync();
+            linkedDocument.ContentServiceId = newGuid;
+            linkedDocument.Filename = Path.GetFileName(message.Filepath)?.Trim();
+            linkedDocument.Filepath = Path.GetDirectoryName(message.Filepath)?.Trim();
+            linkedDocument.Status = SourceDocumentRetrievalStatus.FileGenerated.ToString();
         }
 
         private async Task UpdateDatabaseDocuments(PersistDocumentInStoreCommand message, Guid newGuid)

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Messages/PersistDocumentInStoreCommand.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Messages/PersistDocumentInStoreCommand.cs
@@ -11,5 +11,6 @@ namespace SourceDocumentCoordinator.Messages
         public int SourceDocumentId { get; set; }
         public SourceType SourceType { get; set; }
         public string Filepath { get; set; }
+        public Guid UniqueId { get; set; }
     }
 }

--- a/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Sagas/SourceDocumentRetrievalSaga.cs
+++ b/src/SourceDocumentCoordinator/SourceDocumentCoordinator/Sagas/SourceDocumentRetrievalSaga.cs
@@ -157,7 +157,8 @@ namespace SourceDocumentCoordinator.Sagas
                         ProcessId = Data.ProcessId,
                         SourceDocumentId = message.SourceDocumentId,
                         SourceType = message.SourceType,
-                        Filepath = sourceDocument.Message
+                        Filepath = sourceDocument.Message,
+                        UniqueId =  message.UniqueId
                     };
                     await context.SendLocal(persistCommand).ConfigureAwait(false);
 


### PR DESCRIPTION
- Having posted a linked document to the Content Service, use the UniqueId property to retrieve the relevant row and update it with the Content Serviice GUID
- Fix unit tests