### PR TITLE
ncne : Fixing issue in disabling 3ps controls after chart publish

### DIFF
--- a/src/NCNEPortal/wwwroot/js/Workflow.js
+++ b/src/NCNEPortal/wwwroot/js/Workflow.js
@@ -31,14 +31,6 @@
         $('#HundredPCheckUpn').val(suggestionObject.userPrincipalName);
     });
 
-
-    if (isPublished) {
-        $("#3psToggle").prop("disabled", true);
-        $("#SendDate3ps").prop("disabled", true);
-        $("#ExpectedReturnDate3ps").prop("disabled", true);
-        $("#ActualReturnDate3ps").prop("disabled", true);
-    }
-
     var formChanged = false;
     $("#frmWorkflow").change(function () { formChanged = true; });
     
@@ -594,7 +586,15 @@
          $("#lblRepDate").hide();
      }
 
-    set3psStatus();
+
+    if (isPublished) {
+        $("#3psToggle").prop("disabled", true);
+        $("#SendDate3ps").prop("disabled", true);
+        $("#ExpectedReturnDate3ps").prop("disabled", true);
+        $("#ActualReturnDate3ps").prop("disabled", true);
+    } else {
+        set3psStatus();
+    }
 
     $("#3psToggle").on("change",
         function() {


### PR DESCRIPTION
Disabling the 3PS controls for task with published charts ( It was not working before because of the call to set3psstatus function after disabling)