### PR TITLE
NCNE : Fixing chartnumber clearing issue after CARIS project creation

### DIFF
--- a/src/NCNEPortal/Pages/Workflow.cshtml
+++ b/src/NCNEPortal/Pages/Workflow.cshtml
@@ -128,6 +128,7 @@
         <input type="hidden" id="hdnProcessId" value="@Model.ProcessId" />
         <input type="hidden" asp-for="ProcessId" />
         <input type="hidden" asp-for="ChartType" />
+        <input type="hidden" id="hdnChartNo" asp-for="ChartNo" />
         <input type="hidden" asp-for="IsReadOnly" />
         <input type="hidden" asp-for="IsPublished" />
 
@@ -364,7 +365,7 @@
                             </div>
                             <div class="row">
                                 <div class="col">
-                                    <button id="btnCreateCarisProject" class="btn btn-block btn-primary">
+                                    <button type="button" id="btnCreateCarisProject" class="btn btn-block btn-primary">
                                         <span id="createCarisProjectSpinner" class="fas fa-crosshairs fa-spin" style="margin-right: 10px; display: none;"></span>
                                         Create CARIS Project
                                     </button>

--- a/src/NCNEPortal/Pages/Workflow.cshtml.cs
+++ b/src/NCNEPortal/Pages/Workflow.cshtml.cs
@@ -48,7 +48,6 @@ namespace NCNEPortal
         [DisplayName("Chart title")] public string ChartTitle { get; set; }
 
         [DisplayName("Chart number")]
-        [BindProperty]
         public string ChartNo { get; set; }
 
 
@@ -721,7 +720,7 @@ namespace NCNEPortal
             return inProgress.Any() ? inProgress.First().TaskStageType.Name : "Awaiting Completion";
         }
 
-        public async Task<IActionResult> OnPostSaveAsync(int processId, string chartType)
+        public async Task<IActionResult> OnPostSaveAsync(int processId, string chartType, string chartNo)
         {
 
             LogContext.PushProperty("ProcessId", processId);
@@ -730,7 +729,7 @@ namespace NCNEPortal
 
             ValidationErrorMessages.Clear();
 
-
+            ChartNo = chartNo;
             var role = new TaskRole()
             {
                 ProcessId = processId,

--- a/src/NCNEPortal/Pages/Workflow.cshtml.cs
+++ b/src/NCNEPortal/Pages/Workflow.cshtml.cs
@@ -48,6 +48,7 @@ namespace NCNEPortal
         [DisplayName("Chart title")] public string ChartTitle { get; set; }
 
         [DisplayName("Chart number")]
+        [BindProperty]
         public string ChartNo { get; set; }
 
 

--- a/src/NCNEPortal/wwwroot/js/Workflow.js
+++ b/src/NCNEPortal/wwwroot/js/Workflow.js
@@ -741,15 +741,17 @@
             $("#btnClose").prop("disabled", true);
             $("#btnSave").prop("disabled", true);
 
-            var formData = $("#frmWorkflow").serialize();
+            $("#hdnChartNo").val($("#ChartNo").val());
 
+            var formData = $("#frmWorkflow").serialize();
+            
             $.ajax({
                 type: "POST",
                 url: "Workflow/?handler=Save",
                 beforeSend: function (xhr) {
                     xhr.setRequestHeader("RequestVerificationToken", $('input:hidden[name="__RequestVerificationToken"]').val());
                 },
-                data: formData,
+                data:  formData,
                 complete: function () {
                     window.setTimeout(function () {
                         //$("#modalWaitAssessDone").modal("hide");
@@ -850,6 +852,7 @@
                 },
                 success: function(data) {
                     $("#createCarisProjectSuccess").collapse("show");
+                    
                 },
                 error: function(error) {
                     setControlState(true);


### PR DESCRIPTION
After CARIS project creation, the chart number field is made read-only. To fix it, added a hidden field and used that for saving the form.