### PR TITLE
Make VerifierAdUserId nullable on DbAssessmentAssessData

### DIFF
--- a/src/Databases/WorkflowDatabase.EF/Models/DbAssessmentAssessData.cs
+++ b/src/Databases/WorkflowDatabase.EF/Models/DbAssessmentAssessData.cs
@@ -22,6 +22,6 @@ namespace WorkflowDatabase.EF.Models
         public virtual AdUser Assessor { get; set; }
         public int? AssessorAdUserId { get; set; }
         public virtual AdUser Verifier { get; set; }
-        public int VerifierAdUserId { get; set; }
+        public int? VerifierAdUserId { get; set; }
     }
 }


### PR DESCRIPTION
- VerifierAdUserId should be a nullable int to allow for a Review task with no Verifier to be progressed to Assess