### PR TITLE
Also add milliseconds to filename of session file

### DIFF
--- a/src/Portal/Portal/wwwroot/js/LaunchCarisModal.js
+++ b/src/Portal/Portal/wwwroot/js/LaunchCarisModal.js
@@ -307,6 +307,7 @@ function generateUniqueSessionFileName(filename) {
         date.getHours(),
         date.getMinutes(),
         date.getSeconds(),
+        date.getMilliseconds(),
         ".",
         arr[1]);
 


### PR DESCRIPTION
- Add milliseconds to the filename of the session file to prevent where double clicking still gives a duplicate download with a (1) in the filename