### PR TITLE
Features/fix duplicate commands on k2 failure

### DIFF
--- a/src/Common.Helpers/DatabasesHelpers.cs
+++ b/src/Common.Helpers/DatabasesHelpers.cs
@@ -57,6 +57,7 @@ namespace Common.Helpers
             workflowDbContext.Database.ExecuteSqlRaw("delete from [WorkflowInstance]");
             workflowDbContext.Database.ExecuteSqlRaw("delete from [AdUsers]");
             workflowDbContext.Database.ExecuteSqlRaw("delete from [CachedHpdWorkspace]");
+            workflowDbContext.Database.ExecuteSqlRaw("delete from [OpenAssessmentsQueue]");
 
             ReSeedWorkflowDbTables(workflowDbContext);
             workflowDbContext.SaveChanges();

--- a/src/Databases/WorkflowDatabase.EF/Models/OpenAssessmentsQueue.cs
+++ b/src/Databases/WorkflowDatabase.EF/Models/OpenAssessmentsQueue.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace WorkflowDatabase.EF.Models
+{
+    public class OpenAssessmentsQueue
+    {
+        public int OpenAssessmentsQueueId { get; set; }
+        public int PrimarySdocId { get; set; }
+        public DateTime Timestamp { get; set; } 
+    }
+}

--- a/src/Databases/WorkflowDatabase.EF/WorkflowDbContext.cs
+++ b/src/Databases/WorkflowDatabase.EF/WorkflowDbContext.cs
@@ -42,6 +42,7 @@ namespace WorkflowDatabase.EF
         public DbSet<AdUser> AdUsers { get; set; }
         public DbSet<CachedHpdWorkspace> CachedHpdWorkspace { get; set; }
         public DbSet<CarisProjectDetails> CarisProjectDetails { get; set; }
+        public DbSet<OpenAssessmentsQueue> OpenAssessmentsQueue { get; set; }   
 
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -101,6 +102,7 @@ namespace WorkflowDatabase.EF
             modelBuilder.Entity<PrimaryDocumentStatus>().Ignore(l => l.ContentServiceUri);
             modelBuilder.Entity<LinkedDocument>().Ignore(l => l.ContentServiceUri);
             modelBuilder.Entity<DatabaseDocumentStatus>().Ignore(l => l.ContentServiceUri);
+            modelBuilder.Entity<OpenAssessmentsQueue>().HasIndex(o => o.PrimarySdocId).IsUnique();
 
             base.OnModelCreating(modelBuilder);
         }

--- a/src/Databases/WorkflowDatabase/Database.SQL.refactorlog
+++ b/src/Databases/WorkflowDatabase/Database.SQL.refactorlog
@@ -420,4 +420,18 @@
     <Property Name="ParentElementType" Value="SqlTable" />
     <Property Name="NewName" Value="OffHoldByAdUserId" />
   </Operation>
+  <Operation Name="Rename Refactor" Key="fc812d76-4396-4b1a-beee-1e0cb85fb35e" ChangeDateTime="09/10/2020 14:30:27">
+    <Property Name="ElementName" Value="[dbo].[OpenAssessmentsToBeProcessedQueue]" />
+    <Property Name="ElementType" Value="SqlTable" />
+    <Property Name="ParentElementName" Value="[dbo]" />
+    <Property Name="ParentElementType" Value="SqlSchema" />
+    <Property Name="NewName" Value="[OpenAssessmentsQueue]" />
+  </Operation>
+  <Operation Name="Rename Refactor" Key="6f5807b8-0964-4510-830e-455f9246981f" ChangeDateTime="09/10/2020 14:31:08">
+    <Property Name="ElementName" Value="[dbo].[OpenAssessmentsQueue].[Id]" />
+    <Property Name="ElementType" Value="SqlSimpleColumn" />
+    <Property Name="ParentElementName" Value="[dbo].[OpenAssessmentsQueue]" />
+    <Property Name="ParentElementType" Value="SqlTable" />
+    <Property Name="NewName" Value="OpenAssessmentsQueueId" />
+  </Operation>
 </Operations>

--- a/src/Databases/WorkflowDatabase/Tables/OpenAssessmentsQueue.sql
+++ b/src/Databases/WorkflowDatabase/Tables/OpenAssessmentsQueue.sql
@@ -1,0 +1,10 @@
+﻿CREATE TABLE [dbo].[OpenAssessmentsQueue]
+(
+	[OpenAssessmentsQueueId] INT NOT NULL PRIMARY KEY IDENTITY, 
+    [PrimarySdocId] INT NOT NULL, 
+    [Timestamp] DATETIME NOT NULL
+)
+
+GO
+
+CREATE UNIQUE INDEX [IX_OpenAssessmentsQueue_PrimarySdocId] ON [dbo].[OpenAssessmentsQueue] ([PrimarySdocId])

--- a/src/Databases/WorkflowDatabase/WorkflowDatabase.sqlproj
+++ b/src/Databases/WorkflowDatabase/WorkflowDatabase.sqlproj
@@ -85,6 +85,7 @@
     <Build Include="Tables\CarisProjectDetails.sql" />
     <Build Include="Tables\AdUsers.sql" />
     <Build Include="Views\DatabaseAssessmentWorkflowData.sql" />
+    <Build Include="Tables\OpenAssessmentsQueue.sql" />
   </ItemGroup>
   <ItemGroup>
     <RefactorLog Include="Database.SQL.refactorlog" />

--- a/src/WorkflowCoordinator/WorkflowCoordinator/Program.cs
+++ b/src/WorkflowCoordinator/WorkflowCoordinator/Program.cs
@@ -24,7 +24,7 @@ namespace WorkflowCoordinator
         private static async Task Main(string[] args)
         {
             var (keyVaultAddress, keyVaultClient) = SecretsHelpers.SetUpKeyVaultClient();
-            var isLocalDebugging = false;
+            var isLocalDebugging = ConfigHelpers.IsLocalDevelopment;
 
             var builder = new HostBuilder()
                 .UseEnvironment(ConfigHelpers.HostBuilderEnvironment)


### PR DESCRIPTION
## WorkflowDatabase

- OpenAssessmentsQueue.sql: added new table

## WorkflowDatabase.EF

- OpenAssessmentsQueue.cs: Added new EF model for OpenAssessmentsQueue table
- WorkflowDbContext.cs: added configuration for OpenAssessmentsQueue EF model

## Common.Helpers

- DatabasesHelpers.cs: Added cleaning of OpenAssessmentsQueue table

## WorkflowDatabase.Tests

- DatabaseIntegrityTests.cs: added integrity test for OpenAssessmentsQueue 

## WorkflowCoordinator

- Program.cs: fixed LocalDevelopment DB connection string
- AssessmentPollingSaga.cs: Use OpenAssessmentsQueue, in addition to workflowInstance, for deciding if sdocId is in our system; improved logging
- StartDbAssessmentSaga.cs: Remove sdocId from OpenAssessmentsQueue once its in our system; improved logging