### PR TITLE
Mitigate event service silent failures

### DIFF
--- a/src/EventServices/EventService/LoggingHelper.cs
+++ b/src/EventServices/EventService/LoggingHelper.cs
@@ -44,6 +44,7 @@ namespace EventService
                 .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
                 .Enrich.FromLogContext()
                 .WriteTo.Console()
+                .WriteTo.File("log.txt", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 5)
                 .WriteTo.MSSqlServer(
                     connectionString: loggingConnectionString,
                     sinkOptions: new SinkOptions


### PR DESCRIPTION
- Increase Polly retry delay to ~ 1 minute
- Add rolling file logging (5 day limit)