### PR TITLE
Timeout fix

### DIFF
--- a/src/DbUpdatePortal/Startup.cs
+++ b/src/DbUpdatePortal/Startup.cs
@@ -110,7 +110,6 @@ namespace DbUpdatePortal
             {
                 options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
                 options.Cookie.IsEssential = true;
-                options.ExpireTimeSpan = TimeSpan.FromHours(startupConfig.CookieTimeoutHours);
                 options.SlidingExpiration = true;
 
             });

--- a/src/NCNEPortal/Startup.cs
+++ b/src/NCNEPortal/Startup.cs
@@ -140,7 +140,6 @@ namespace NCNEPortal
             {
                 options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
                 options.Cookie.IsEssential = true;
-                //options.ExpireTimeSpan = TimeSpan.FromHours(startupConfig.CookieTimeoutHours);
                 options.SlidingExpiration = true;
 
             });

--- a/src/NCNEPortal/Startup.cs
+++ b/src/NCNEPortal/Startup.cs
@@ -140,7 +140,7 @@ namespace NCNEPortal
             {
                 options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
                 options.Cookie.IsEssential = true;
-                options.ExpireTimeSpan = TimeSpan.FromHours(startupConfig.CookieTimeoutHours);
+                //options.ExpireTimeSpan = TimeSpan.FromHours(startupConfig.CookieTimeoutHours);
                 options.SlidingExpiration = true;
 
             });

--- a/src/Portal/Portal/Startup.cs
+++ b/src/Portal/Portal/Startup.cs
@@ -205,7 +205,6 @@ namespace Portal
             {
                 options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
                 options.Cookie.IsEssential = true;
-                options.ExpireTimeSpan = TimeSpan.FromHours(startupConfig.CookieTimeoutHours);
                 options.SlidingExpiration = true;
 
             });


### PR DESCRIPTION
Removed cookie expiry to force cookie life to match session so that it does not interfere with token lifespan set in Azure AD.

Also changed way DbContext decides whether to use access token or not for easier local development.